### PR TITLE
Made Metric Set Sample title cased for Producer and Consumer topic sets

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -4,6 +4,7 @@ package metrics
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/newrelic/infra-integrations-sdk/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/integration"
@@ -35,8 +36,12 @@ func GetProducerMetrics(producerName string, sample *metric.Set) error {
 func CollectTopicSubMetrics(entity *integration.Entity, entityType string,
 	metricSets []*JMXMetricSet, topicList []string,
 	beanModifier func(string, string) func(string) string) {
+
+	// need to title case the type so it matches the metric set of the parent entity
+	titleEntityType := strings.Title(entity.Metadata.Namespace)
+
 	for _, topicName := range topicList {
-		topicSample := entity.NewMetricSet("Kafka"+entity.Metadata.Namespace+"Sample",
+		topicSample := entity.NewMetricSet("Kafka"+titleEntityType+"Sample",
 			metric.Attribute{Key: "displayName", Value: entity.Metadata.Name},
 			metric.Attribute{Key: "entityName", Value: fmt.Sprintf("%s:%s", entity.Metadata.Namespace, entity.Metadata.Name)},
 			metric.Attribute{Key: "topic", Value: topicName},


### PR DESCRIPTION
#### Description of the changes

Noticed Topic metric sets for `producer` and `consumer` entities had metric set named `KafkaproducerSample` and `KafkaconsumerSample` instead of `KafkaProducerSample` and `KafkaConsumerSample` respectively.

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [X] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [X] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
