### PR TITLE
Changed wait group increment to before a worker is created

### DIFF
--- a/brokercollect/broker_collection.go
+++ b/brokercollect/broker_collection.go
@@ -33,6 +33,7 @@ func StartBrokerPool(poolSize int, wg *sync.WaitGroup, zkConn zookeeper.Connecti
 	// Only spin off brokerWorkers if signaled
 	if utils.KafkaArgs.CollectBrokerTopicData && zkConn != nil {
 		for i := 0; i < poolSize; i++ {
+			wg.Add(1)
 			go brokerWorker(brokerChan, collectedTopics, wg, zkConn, integration)
 		}
 	}
@@ -65,7 +66,6 @@ func FeedBrokerPool(zkConn zookeeper.Connection, brokerChan chan<- int) {
 // inventory and metrics data for that broker. Exits when it determines the channel has
 // been closed
 func brokerWorker(brokerChan <-chan int, collectedTopics []string, wg *sync.WaitGroup, zkConn zookeeper.Connection, i *integration.Integration) {
-	wg.Add(1)
 	defer wg.Done()
 
 	for {

--- a/brokercollect/broker_collection_test.go
+++ b/brokercollect/broker_collection_test.go
@@ -82,6 +82,7 @@ func TestBrokerWorker(t *testing.T) {
 	i, _ := integration.New("kafka", "1.0.0")
 	testutils.SetupTestArgs()
 
+	wg.Add(1)
 	go brokerWorker(brokerChan, []string{}, &wg, zkConn, i)
 
 	brokerChan <- 0

--- a/topiccollect/partition_collection.go
+++ b/topiccollect/partition_collection.go
@@ -32,6 +32,7 @@ func startPartitionPool(poolSize int, wg *sync.WaitGroup, zkConn zookeeper.Conne
 	for i := 0; i < poolSize; i++ {
 		partitionOutChan := make(chan interface{}, 20)
 		partitionOutChans = append(partitionOutChans, partitionOutChan)
+		wg.Add(1)
 		go partitionWorker(partitionInChan, partitionOutChan, wg, zkConn)
 	}
 
@@ -140,7 +141,6 @@ func collectPartitions(partitionOutChans []chan interface{}) []*partition {
 
 // Reads partitionSenders from a channel and pushes a completed partition struct onto its unique partitionOutChan
 func partitionWorker(partitionInChan chan *partitionSender, partitionOutChan chan interface{}, wg *sync.WaitGroup, c zookeeper.Connection) {
-	wg.Add(1)
 	defer wg.Done()
 	defer close(partitionOutChan)
 

--- a/topiccollect/partition_collection_test.go
+++ b/topiccollect/partition_collection_test.go
@@ -62,6 +62,7 @@ func TestPartitionWorker(t *testing.T) {
 
 	topicReplication := map[string][]int{"0": {0, 1, 2}}
 
+	wg.Add(1)
 	go partitionWorker(partitionInChan, partitionOutChan, &wg, &zkConn)
 
 	partitionInChan <- &partitionSender{

--- a/topiccollect/topic_collection.go
+++ b/topiccollect/topic_collection.go
@@ -33,6 +33,7 @@ func StartTopicPool(poolSize int, wg *sync.WaitGroup, zkConn zookeeper.Connectio
 
 	if utils.KafkaArgs.CollectBrokerTopicData && zkConn != nil {
 		for i := 0; i < poolSize; i++ {
+			wg.Add(1)
 			go topicWorker(topicChan, wg, zkConn)
 		}
 	}
@@ -86,7 +87,6 @@ func FeedTopicPool(topicChan chan<- *Topic, integration *integration.Integration
 
 // Collect inventory and metrics for topics sent down topicChan
 func topicWorker(topicChan <-chan *Topic, wg *sync.WaitGroup, zkConn zookeeper.Connection) {
-	wg.Add(1)
 	defer wg.Done()
 
 	for {

--- a/topiccollect/topic_collection_test.go
+++ b/topiccollect/topic_collection_test.go
@@ -161,6 +161,7 @@ func TestTopicWorker(t *testing.T) {
 		t.Error(err)
 	}
 
+	wg.Add(1)
 	go topicWorker(topicChan, &wg, &zkConn)
 
 	myTopic := &Topic{


### PR DESCRIPTION
#### Description of the changes

Moved all `wg.Add` calls to before a worker is spun off rather than in the worker. It doesn't seem to have had a negative impact but would have had a race condition where some workers may have never been utilized.

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [X] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [X] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
