### PR TITLE
Changed all metric.RATE source types to metric.GAUGE

### DIFF
--- a/metrics/broker_definitions.go
+++ b/metrics/broker_definitions.go
@@ -100,17 +100,17 @@ var brokerMetricDefs = []*JMXMetricSet{
 		MetricDefs: []*MetricDefinition{
 			{
 				Name:       "replication.isrExpandsPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "name=IsrExpandsPerSec,attr=Count",
 			},
 			{
 				Name:       "replication.isrShrinksPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "name=IsrShrinksPerSec,attr=Count",
 			},
 			{
 				Name:       "replication.unreplicatedPartitions",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "name=UnderReplicatedPartitions,attr=Value",
 			},
 		},
@@ -122,12 +122,12 @@ var brokerMetricDefs = []*JMXMetricSet{
 		MetricDefs: []*MetricDefinition{
 			{
 				Name:       "replication.leaderElectionPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "name=LeaderElectionRateAndTimeMs,attr=Count",
 			},
 			{
 				Name:       "replication.uncleanLeaderElectionPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "name=UncleanLeaderElectionsPerSec,attr=Count",
 			},
 		},
@@ -139,32 +139,32 @@ var brokerMetricDefs = []*JMXMetricSet{
 		MetricDefs: []*MetricDefinition{
 			{
 				Name:       "broker.IOInPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "name=BytesInPerSec,attr=Count",
 			},
 			{
 				Name:       "broker.IOOutPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "name=BytesOutPerSec,attr=Count",
 			},
 			{
 				Name:       "messagesInPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "name=MessagesInPerSec,attr=Count",
 			},
 			{
 				Name:       "net.bytesRejectedPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "name=BytesRejectedPerSec,attr=Count",
 			},
 			{
 				Name:       "requests.clientFetchesFailedPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "name=FailedFetchRequestsPerSec,attr=Count",
 			},
 			{
 				Name:       "requests.produceRequestsFailedPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "name=FailedProduceRequestsPerSec,attr=Count",
 			},
 		},
@@ -200,12 +200,12 @@ var brokerMetricDefs = []*JMXMetricSet{
 		MetricDefs: []*MetricDefinition{
 			{
 				Name:       "consumer.requestsExpiredPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "fetcherType=consumer,attr=Count",
 			},
 			{
 				Name:       "follower.requestExpirationPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "fetcherType=follower,attr=Count",
 			},
 		},

--- a/metrics/consumer_definitions.go
+++ b/metrics/consumer_definitions.go
@@ -16,12 +16,12 @@ var consumerMetricDefs = []*JMXMetricSet{
 		MetricDefs: []*MetricDefinition{
 			{
 				Name:       "consumer.bytesInPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "attr=bytes-consumed-rate",
 			},
 			{
 				Name:       "consumer.fetchPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "attr=fetch-rate",
 			},
 			{
@@ -31,7 +31,7 @@ var consumerMetricDefs = []*JMXMetricSet{
 			},
 			{
 				Name:       "consumer.messageConsumptionPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "attr=records-consumed-rate",
 			},
 		},
@@ -42,12 +42,12 @@ var consumerMetricDefs = []*JMXMetricSet{
 		MetricDefs: []*MetricDefinition{
 			{
 				Name:       "consumer.offsetKafkaCommitsPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "name=KafkaCommitsPerSec,clientId=" + consumerHolder + "attr=Count",
 			},
 			{
 				Name:       "consumer.offsetZooKeeperCommitsPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "name=ZooKeeperCommitsPerSec,clientId=" + consumerHolder + "attr=Count",
 			},
 		},
@@ -72,7 +72,7 @@ var ConsumerTopicMetricDefs = []*JMXMetricSet{
 			},
 			{
 				Name:       "consumer.avgRecordConsumedPerTopicPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "attr=records-consumed-rate",
 			},
 			{

--- a/metrics/producer_definitions.go
+++ b/metrics/producer_definitions.go
@@ -36,12 +36,12 @@ var producerMetricDefs = []*JMXMetricSet{
 			},
 			{
 				Name:       "producer.avgRecordsSentPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "client-id=" + producerHolder + ",attr=record-send-rate",
 			},
 			{
 				Name:       "producer.avgRequestLatencyPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "client-id=" + producerHolder + ",attr=request-latency-avg",
 			},
 			{
@@ -56,7 +56,7 @@ var producerMetricDefs = []*JMXMetricSet{
 			},
 			{
 				Name:       "producer.bytesOutPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "client-id=" + producerHolder + ",attr=outgoing-byte-rate",
 			},
 			{
@@ -86,7 +86,7 @@ var producerMetricDefs = []*JMXMetricSet{
 			},
 			{
 				Name:       "producer.requestPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "client-id=" + producerHolder + ",attr=request-rate",
 			},
 			{
@@ -96,7 +96,7 @@ var producerMetricDefs = []*JMXMetricSet{
 			},
 			{
 				Name:       "producer.responsePerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "client-id=" + producerHolder + ",attr=response-rate",
 			},
 			{
@@ -122,7 +122,7 @@ var producerMetricDefs = []*JMXMetricSet{
 		MetricDefs: []*MetricDefinition{
 			{
 				Name:       "producer.messageRatePerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "client-id=" + producerHolder + ",attr=Count",
 			},
 		},
@@ -144,7 +144,7 @@ var ProducerTopicMetricDefs = []*JMXMetricSet{
 		MetricDefs: []*MetricDefinition{
 			{
 				Name:       "producer.avgRecordsSentPerTopicPerSecond",
-				SourceType: metric.RATE,
+				SourceType: metric.GAUGE,
 				JMXAttr:    "attr=record-send-rate",
 			},
 		},


### PR DESCRIPTION
#### Description of the changes

After viewing metrics in Insights for several hours it seems like all Kafka's metrics with source type `RATE` were either flat or had nonsensical values. After some research it seems like Kafka precalculates all of it's rate metrics. Changed all source types to `GAUGE` to reflect this.

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [X] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [X] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
