### PR TITLE
Added docker makefile to allow compatibility builds

### DIFF
--- a/Makefile-docker.mk
+++ b/Makefile-docker.mk
@@ -1,0 +1,14 @@
+DOCKER_IMAGE := golang:1.9
+INTEGRATION_DIR := nri-$(INTEGRATION)
+
+docker-fmt:
+	@echo "=== $(INTEGRATION) === [ docker-fmt ]: Running gofmt in Docker..."
+	@echo "Using Docker image $(DOCKER_IMAGE)"
+	@docker run -it --rm -v $(PWD):/go/src/github.com/newrelic/$(INTEGRATION_DIR) -w /go/src/github.com/newrelic/$(INTEGRATION_DIR) $(DOCKER_IMAGE) "gofmt" "-s" "-w" "."
+
+docker-make:
+	@echo "=== $(INTEGRATION) === [ docker-fmt ]: Running make in Docker..."
+	@echo "Using Docker image $(DOCKER_IMAGE)"
+	@docker run -it --rm -v $(PWD):/go/src/github.com/newrelic/$(INTEGRATION_DIR) -w /go/src/github.com/newrelic/$(INTEGRATION_DIR) $(DOCKER_IMAGE) "make"
+
+.PHONY: docker-fmt docker-make


### PR DESCRIPTION
#### Description of the changes

As Jenkins is targeting Go 1.9 for building, I added `Makefile-docker.mk` with two commands that allow running `gofmt` and `make` in a 1.9 environment. This should help mitigate any issues with a dev box not having Go version 1.9.

#### PR Review Checklist
### Author

- [X] add a risk label after carefully considering the "blast radius" of your changes
- [X] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [X] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
