### PR TITLE
Added nrjmx dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.1.4 - 2018-09-10
+### Added
+- Added nrjmx dependency when installing the package
+
 ## 0.1.3 - 2018-09-06
 ### Added
 - Added additional debug logging statements to assist in debugging a customers environment

--- a/Makefile-package.mk
+++ b/Makefile-package.mk
@@ -11,7 +11,7 @@ PACKAGER           = "New Relic Infrastructure Team <infrastructure-eng@newrelic
 PACKAGE_URL        = "https://www.newrelic.com/infrastructure"
 SUMMARY            = "New Relic Infrastructure $(INTEGRATION) Integration"
 DESCRIPTION        = "New Relic Infrastructure $(INTEGRATION) Integration extend the core New Relic\nInfrastructure agent's capabilities to allow you to collect metric and\nlive state data from $(INTEGRATION) components."
-FPM_COMMON_OPTIONS = --verbose -C $(SOURCE_DIR) -s dir -n $(PROJECT_NAME) -v $(VERSION) --iteration $(RELEASE) --prefix "" --license $(LICENSE) --vendor $(VENDOR) -m $(PACKAGER) --url $(PACKAGE_URL) --config-files /etc/newrelic-infra/ --description "$$(printf $(DESCRIPTION))" --depends "newrelic-infra >= 1.0.726"
+FPM_COMMON_OPTIONS = --verbose -C $(SOURCE_DIR) -s dir -n $(PROJECT_NAME) -v $(VERSION) --iteration $(RELEASE) --prefix "" --license $(LICENSE) --vendor $(VENDOR) -m $(PACKAGER) --url $(PACKAGE_URL) --config-files /etc/newrelic-infra/ --description "$$(printf $(DESCRIPTION))" --depends "newrelic-infra >= 1.0.726" --depends "nrjmx"
 FPM_DEB_OPTIONS    = -t deb -p $(PACKAGES_DIR)/deb/
 FPM_RPM_OPTIONS    = -t rpm -p $(PACKAGES_DIR)/rpm/ --epoch 0 --rpm-summary $(SUMMARY)
 


### PR DESCRIPTION
nrjmx is necessary to run the integration and the dependency was missing when installing the package.