### PR TITLE
Possible to utilize multiple connection types to kafka broker

### DIFF
--- a/src/brokercollect/broker_collection.go
+++ b/src/brokercollect/broker_collection.go
@@ -86,7 +86,7 @@ func brokerWorker(brokerChan <-chan int, collectedTopics []string, wg *sync.Wait
 		}
 
 		// Create Broker
-		brokers, err := createBrokers(brokerID, zkConn, i)
+		brokers, err := createBrokerConnectionVariants(brokerID, zkConn, i)
 		if err != nil {
 			continue
 		}
@@ -109,16 +109,16 @@ func brokerWorker(brokerChan <-chan int, collectedTopics []string, wg *sync.Wait
 				}
 				log.Debug("Done Collecting metrics for broker %s", broker.Entity.Metadata.Name)
 			}
+			break
 		}
 	}
 }
 
-// Creates and populates an array of broker structs with all the information needed to
-// populate inventory and metrics.
-func createBrokers(brokerID int, zkConn zookeeper.Connection, i *integration.Integration) ([]*broker, error) {
+// Creates and populates an array of different ways to connect to one broker.
+func createBrokerConnectionVariants(brokerID int, zkConn zookeeper.Connection, i *integration.Integration) ([]*broker, error) {
 
 	// Collect broker connection information from ZooKeeper
-	brokerConnections, err := zookeeper.GetBrokerConnectionInfo(brokerID, zkConn)
+	brokerConnections, err := zookeeper.GetBrokerConnections(brokerID, zkConn)
 	if err != nil {
 		log.Error("Unable to get broker JMX information for broker id %d: %s", brokerID, err)
 		return nil, err

--- a/src/brokercollect/broker_collection_test.go
+++ b/src/brokercollect/broker_collection_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	brokerConnectionBytes = []byte(`{"listener_security_protocol_map":{"PLAINTEXT":"PLAINTEXT", "SSL":"SLL"},"endpoints":["PLAINTEXT://kafkabroker:9092", "SSL://kafkabroker:9093"],"jmx_port":9999,"host":"kafkabroker","timestamp":"1530886155628","port":9092,"version":4}`)
+	brokerConnectionBytes = []byte(`{"listener_security_protocol_map":{"PLAINTEXT":"PLAINTEXT", "SSL":"SSL"},"endpoints":["PLAINTEXT://kafkabroker:9092", "SSL://kafkabroker:9093"],"jmx_port":9999,"host":"kafkabroker","timestamp":"1530886155628","port":9092,"version":4}`)
 	brokerConfigBytes     = []byte(`{"version":1,"config":{"flush.messages":"12345"}}`)
 	brokerConfigBytes2    = []byte(`{"version":1,"config":{"leader.replication.throttled.replicas":"10000"}}`)
 )
@@ -77,7 +77,7 @@ func TestCreateBroker_ZKError(t *testing.T) {
 	zkConn.On("Get", "/brokers/ids/0").Return([]byte{}, new(zk.Stat), errors.New("this is a test error"))
 	i, _ := integration.New("kafka", "1.0.0")
 
-	_, err := createBrokers(brokerID, zkConn, i)
+	_, err := createBrokerConnectionVariants(brokerID, zkConn, i)
 	if err == nil {
 		t.Error("Expected error")
 	}
@@ -89,7 +89,7 @@ func TestCreateBroker_Normal(t *testing.T) {
 	zkConn.On("Get", "/config/brokers/0").Return(brokerConfigBytes, new(zk.Stat), nil)
 	i, _ := integration.New("kafka", "1.0.0")
 
-	brokers, err := createBrokers(brokerID, zkConn, i)
+	brokers, err := createBrokerConnectionVariants(brokerID, zkConn, i)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err.Error())
 	}
@@ -251,7 +251,7 @@ func TestGetBrokerJMX(t *testing.T) {
 		},
 	}
 
-	brokerConnections, err := zookeeper.GetBrokerConnectionInfo(brokerID, &zkConn)
+	brokerConnections, err := zookeeper.GetBrokerConnections(brokerID, &zkConn)
 	if err != nil {
 		t.Error(err)
 	}

--- a/src/brokercollect/broker_collection_test.go
+++ b/src/brokercollect/broker_collection_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	brokerConnectionBytes = []byte(`{"listener_security_protocol_map":{"PLAINTEXT":"PLAINTEXT"},"endpoints":["PLAINTEXT://kafkabroker:9092"],"jmx_port":9999,"host":"kafkabroker","timestamp":"1530886155628","port":9092,"version":4}`)
+	brokerConnectionBytes = []byte(`{"listener_security_protocol_map":{"PLAINTEXT":"PLAINTEXT", "SSL":"SLL"},"endpoints":["PLAINTEXT://kafkabroker:9092", "SSL://kafkabroker:9093"],"jmx_port":9999,"host":"kafkabroker","timestamp":"1530886155628","port":9092,"version":4}`)
 	brokerConfigBytes     = []byte(`{"version":1,"config":{"flush.messages":"12345"}}`)
 	brokerConfigBytes2    = []byte(`{"version":1,"config":{"leader.replication.throttled.replicas":"10000"}}`)
 )
@@ -77,7 +77,7 @@ func TestCreateBroker_ZKError(t *testing.T) {
 	zkConn.On("Get", "/brokers/ids/0").Return([]byte{}, new(zk.Stat), errors.New("this is a test error"))
 	i, _ := integration.New("kafka", "1.0.0")
 
-	_, err := createBroker(brokerID, zkConn, i)
+	_, err := createBrokers(brokerID, zkConn, i)
 	if err == nil {
 		t.Error("Expected error")
 	}
@@ -89,32 +89,43 @@ func TestCreateBroker_Normal(t *testing.T) {
 	zkConn.On("Get", "/config/brokers/0").Return(brokerConfigBytes, new(zk.Stat), nil)
 	i, _ := integration.New("kafka", "1.0.0")
 
-	b, err := createBroker(brokerID, zkConn, i)
+	brokers, err := createBrokers(brokerID, zkConn, i)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err.Error())
 	}
 
-	expectedBroker := &broker{
-		Host:      "kafkabroker",
-		KafkaPort: 9092,
-		JMXPort:   9999,
-		ID:        0,
+	expectedBrokers := []broker{
+		{
+			Host:      "kafkabroker",
+			KafkaPort: 9092,
+			JMXPort:   9999,
+			ID:        0,
+		},
+		{
+			Host:      "kafkabroker",
+			KafkaPort: 9093,
+			JMXPort:   9999,
+			ID:        0,
+		},
 	}
 
-	if expectedBroker.Host != b.Host {
-		t.Errorf("Expected JMX host '%s' got '%s'", expectedBroker.Host, b.Host)
-	}
-	if expectedBroker.JMXPort != b.JMXPort {
-		t.Errorf("Expected JMX Port '%d' got '%d'", expectedBroker.JMXPort, b.JMXPort)
-	}
-	if expectedBroker.KafkaPort != b.KafkaPort {
-		t.Errorf("Expected Kafka Port '%d' got '%d'", expectedBroker.KafkaPort, b.KafkaPort)
-	}
-	if b.Entity.Metadata.Name != "kafkabroker:9092" {
-		t.Errorf("Expected entity name '%s' got '%s'", expectedBroker.Host, b.Entity.Metadata.Name)
-	}
-	if b.Entity.Metadata.Namespace != "ka-broker" {
-		t.Errorf("Expected entity name '%s' got '%s'", "ka-broker", b.Entity.Metadata.Namespace)
+	for i, broker := range brokers {
+		if expectedBrokers[i].Host != broker.Host {
+			t.Errorf("Expected JMX host '%s' got '%s'", expectedBrokers[i].Host, broker.Host)
+		}
+		if expectedBrokers[i].JMXPort != broker.JMXPort {
+			t.Errorf("Expected JMX Port '%d' got '%d'", expectedBrokers[i].JMXPort, broker.JMXPort)
+		}
+		if expectedBrokers[i].KafkaPort != broker.KafkaPort {
+			t.Errorf("Expected Kafka Port '%d' got '%d'", expectedBrokers[i].KafkaPort, broker.KafkaPort)
+		}
+		metadataName := fmt.Sprintf("%s:%d", expectedBrokers[i].Host, expectedBrokers[i].KafkaPort)
+		if broker.Entity.Metadata.Name != metadataName {
+			t.Errorf("Expected entity name '%s' got '%s'", metadataName, broker.Entity.Metadata.Name)
+		}
+		if broker.Entity.Metadata.Namespace != "ka-broker" {
+			t.Errorf("Expected entity name '%s' got '%s'", "ka-broker", broker.Entity.Metadata.Namespace)
+		}
 	}
 }
 
@@ -225,23 +236,39 @@ func TestGetBrokerJMX(t *testing.T) {
 	brokerID := 0
 	zkConn := zookeeper.MockConnection{}
 	zkConn.On("Get", "/brokers/ids/0").Return(brokerConnectionBytes, new(zk.Stat), nil)
+	expectedBrokers := []zookeeper.BrokerConnection{
+		{
+			Scheme:     "http",
+			BrokerHost: "kafkabroker",
+			BrokerPort: 9092,
+			JmxPort:    9999,
+		},
+		{
+			Scheme:     "https",
+			BrokerHost: "kafkabroker",
+			BrokerPort: 9093,
+			JmxPort:    9999,
+		},
+	}
 
-	scheme, host, jmxPort, kafkaPort, err := zookeeper.GetBrokerConnectionInfo(brokerID, &zkConn)
+	brokerConnections, err := zookeeper.GetBrokerConnectionInfo(brokerID, &zkConn)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if scheme != "http" {
-		t.Errorf("Expected scheme http, got %s", scheme)
-	}
-	if host != "kafkabroker" {
-		t.Errorf("Expected host kafkabroker, got %s", host)
-	}
-	if kafkaPort != 9092 {
-		t.Errorf("Expected kafka port 9092, got %d", kafkaPort)
-	}
-	if jmxPort != 9999 {
-		t.Errorf("Expected jmx port 9999, got %d", jmxPort)
+	for i, brokerConnection := range brokerConnections {
+		if brokerConnection.Scheme != expectedBrokers[i].Scheme {
+			t.Errorf("Expected scheme %s, got %s", expectedBrokers[i].Scheme, brokerConnection.Scheme)
+		}
+		if brokerConnection.BrokerHost != expectedBrokers[i].BrokerHost {
+			t.Errorf("Expected host %s, got %s", expectedBrokers[i].BrokerHost, brokerConnection.BrokerHost)
+		}
+		if brokerConnection.BrokerPort != expectedBrokers[i].BrokerPort {
+			t.Errorf("Expected kafka port %d, got %d", expectedBrokers[i].BrokerPort, brokerConnection.BrokerPort)
+		}
+		if brokerConnection.JmxPort != expectedBrokers[i].JmxPort {
+			t.Errorf("Expected jmx port %d, got %d", expectedBrokers[i].JmxPort, brokerConnection.JmxPort)
+		}
 	}
 }
 

--- a/src/topiccollect/topic_collection.go
+++ b/src/topiccollect/topic_collection.go
@@ -218,17 +218,21 @@ func calculateUnderReplicatedCount(partitions []*partition, sample *metric.Set) 
 func topicRespondsToMetadata(t *Topic, zkConn zookeeper.Connection) int {
 
 	// Get connection information for a broker
-	_, host, _, port, err := zookeeper.GetBrokerConnectionInfo(0, zkConn)
+	connections, err := zookeeper.GetBrokerConnectionInfo(0, zkConn)
 	if err != nil {
 		return 0
 	}
 
+	var broker *sarama.Broker
+
 	// Create a broker connection object and open the connection
-	broker := sarama.NewBroker(fmt.Sprintf("%s:%d", host, port))
-	config := sarama.NewConfig()
-	err = broker.Open(config)
-	if err != nil {
-		return 0
+	for _, connection := range connections {
+		broker = sarama.NewBroker(fmt.Sprintf("%s:%d", connection.BrokerHost, connection.BrokerPort))
+		config := sarama.NewConfig()
+		err = broker.Open(config)
+		if err != nil {
+			return 0
+		}
 	}
 
 	defer func() {

--- a/src/topiccollect/topic_collection.go
+++ b/src/topiccollect/topic_collection.go
@@ -218,7 +218,7 @@ func calculateUnderReplicatedCount(partitions []*partition, sample *metric.Set) 
 func topicRespondsToMetadata(t *Topic, zkConn zookeeper.Connection) int {
 
 	// Get connection information for a broker
-	connections, err := zookeeper.GetBrokerConnectionInfo(0, zkConn)
+	connections, err := zookeeper.GetBrokerConnections(0, zkConn)
 	if err != nil {
 		return 0
 	}

--- a/src/zookeeper/connection_test.go
+++ b/src/zookeeper/connection_test.go
@@ -20,7 +20,7 @@ func Test_GetBrokerConnectionInfo_WithHost(t *testing.T) {
 		{Scheme: "http", BrokerHost: "my-broker.host", JmxPort: 9999, BrokerPort: 9092},
 	}
 
-	brokerConnections, err := GetBrokerConnectionInfo(brokerID, &zkConn)
+	brokerConnections, err := GetBrokerConnections(brokerID, &zkConn)
 	if err != nil {
 		t.Fatalf("Unexpected error %s", err.Error())
 	}
@@ -56,7 +56,7 @@ func Test_GetBrokerConnectionInfo_WithProtocolMap(t *testing.T) {
 		{Scheme: "http", BrokerHost: "my-broker.host", JmxPort: 9999, BrokerPort: 9093},
 	}
 
-	brokerConnections, err := GetBrokerConnectionInfo(brokerID, &zkConn)
+	brokerConnections, err := GetBrokerConnections(brokerID, &zkConn)
 
 	if err != nil {
 		t.Fatalf("Unexpected error %s", err.Error())

--- a/src/zookeeper/connection_test.go
+++ b/src/zookeeper/connection_test.go
@@ -13,26 +13,35 @@ func Test_GetBrokerConnectionInfo_WithHost(t *testing.T) {
 
 	brokerID := 0
 	zkConn := MockConnection{}
-	zkConn.On("Get", "/brokers/ids/0").Return([]byte(`{"listener_security_protocol_map":{"SASL_SSL":"SASL_SSL","SSL":"SSL"},"endpoints":["SASL_SSL://my-broker.host:9193","SSL://my-broker.host:9093"],"rack":"us-east-1d","jmx_port":9999,"host":null,"timestamp":"1542127633364","port":-1,"version":4}`), new(zk.Stat), nil)
+	zkConn.On("Get", "/brokers/ids/0").Return([]byte(`{"listener_security_protocol_map":{"SASL_SSL":"SASL_SSL","SSL":"SSL", "PLAINTEXT":"PLAINTEXT"},"endpoints":["SASL_SSL://my-broker.host:9193","SSL://my-broker.host:9093","PLAINTEXT://my-broker.host:9092"],"rack":"us-east-1d","jmx_port":9999,"host":null,"timestamp":"1542127633364","port":-1,"version":4}`), new(zk.Stat), nil)
 
-	expectedScheme, expectedHost, expectedJMXPort, expectedKafkaPort := "https", "my-broker.host", 9999, 9093
+	expectedValues := []BrokerConnection{
+		{Scheme: "https", BrokerHost: "my-broker.host", JmxPort: 9999, BrokerPort: 9093},
+		{Scheme: "http", BrokerHost: "my-broker.host", JmxPort: 9999, BrokerPort: 9092},
+	}
 
-	scheme, host, jmxPort, kafkaPort, err := GetBrokerConnectionInfo(brokerID, &zkConn)
+	brokerConnections, err := GetBrokerConnectionInfo(brokerID, &zkConn)
 	if err != nil {
 		t.Fatalf("Unexpected error %s", err.Error())
 	}
 
-	if scheme != expectedScheme {
-		t.Errorf("Expected %s got %s", expectedScheme, scheme)
+	if len(expectedValues) != len(brokerConnections) {
+		t.Errorf("Expected %d entires got %d", len(expectedValues), len(brokerConnections))
 	}
-	if host != expectedHost {
-		t.Errorf("Expected %s got %s", expectedHost, host)
-	}
-	if jmxPort != expectedJMXPort {
-		t.Errorf("Expected %d got %d", expectedJMXPort, jmxPort)
-	}
-	if kafkaPort != expectedKafkaPort {
-		t.Errorf("Expected %d got %d", expectedKafkaPort, kafkaPort)
+
+	for i, brokerConnection := range brokerConnections {
+		if brokerConnection.Scheme != expectedValues[i].Scheme {
+			t.Errorf("Expected %s got %s", expectedValues[i].Scheme, brokerConnection.Scheme)
+		}
+		if brokerConnection.BrokerHost != expectedValues[i].BrokerHost {
+			t.Errorf("Expected %s got %s", expectedValues[i].BrokerHost, brokerConnection.BrokerHost)
+		}
+		if brokerConnection.JmxPort != expectedValues[i].JmxPort {
+			t.Errorf("Expected %d got %d", expectedValues[i].JmxPort, brokerConnection.JmxPort)
+		}
+		if brokerConnection.BrokerPort != expectedValues[i].BrokerPort {
+			t.Errorf("Expected %d got %d", expectedValues[i].BrokerPort, brokerConnection.BrokerPort)
+		}
 	}
 }
 
@@ -43,49 +52,67 @@ func Test_GetBrokerConnectionInfo_WithProtocolMap(t *testing.T) {
 	zkConn := MockConnection{}
 	zkConn.On("Get", "/brokers/ids/0").Return([]byte(`{"listener_security_protocol_map":{"EXTERNAL":"SASL_SSL","INTERNAL":"PLAINTEXT"},"endpoints":["EXTERNAL://my-broker.host:9193", "INTERNAL://my-broker.host:9093"],"rack":"us-east-1d","jmx_port":9999,"host":null,"timestamp":"1542127633364","port":-1,"version":4}`), new(zk.Stat), nil)
 
-	expectedScheme, expectedHost, expectedJMXPort, expectedKafkaPort := "http", "my-broker.host", 9999, 9093
+	expectedValues := []BrokerConnection{
+		{Scheme: "http", BrokerHost: "my-broker.host", JmxPort: 9999, BrokerPort: 9093},
+	}
 
-	scheme, host, jmxPort, kafkaPort, err := GetBrokerConnectionInfo(brokerID, &zkConn)
+	brokerConnections, err := GetBrokerConnectionInfo(brokerID, &zkConn)
+
 	if err != nil {
 		t.Fatalf("Unexpected error %s", err.Error())
 	}
 
-	if scheme != expectedScheme {
-		t.Errorf("Expected %s got %s", expectedScheme, scheme)
+	if len(expectedValues) != len(brokerConnections) {
+		t.Errorf("Expected %d entires got %d", len(expectedValues), len(brokerConnections))
 	}
-	if host != expectedHost {
-		t.Errorf("Expected %s got %s", expectedHost, host)
-	}
-	if jmxPort != expectedJMXPort {
-		t.Errorf("Expected %d got %d", expectedJMXPort, jmxPort)
-	}
-	if kafkaPort != expectedKafkaPort {
-		t.Errorf("Expected %d got %d", expectedKafkaPort, kafkaPort)
+
+	for i, brokerConnection := range brokerConnections {
+		if brokerConnection.Scheme != expectedValues[i].Scheme {
+			t.Errorf("Expected %s got %s", expectedValues[i].Scheme, brokerConnection.Scheme)
+		}
+		if brokerConnection.BrokerHost != expectedValues[i].BrokerHost {
+			t.Errorf("Expected %s got %s", expectedValues[i].BrokerHost, brokerConnection.BrokerHost)
+		}
+		if brokerConnection.JmxPort != expectedValues[i].JmxPort {
+			t.Errorf("Expected %d got %d", expectedValues[i].JmxPort, brokerConnection.JmxPort)
+		}
+		if brokerConnection.BrokerPort != expectedValues[i].BrokerPort {
+			t.Errorf("Expected %d got %d", expectedValues[i].BrokerPort, brokerConnection.BrokerPort)
+		}
 	}
 }
 
 func Test_getUrlStringAndSchemeFromEndpoints_WithVanilla(t *testing.T) {
 	testutils.SetupTestArgs()
 
-	endpoints := []string{"SASL_SSL://my-broker.host:9193", "SSL://my-broker.host:9093"}
+	endpoints := []string{"SASL_SSL://my-broker.host:9193", "SSL://my-broker.host:9093", "PLAINTEXT://my-broker.host:9092"}
 	protocolMap := map[string]string{
-		"SASL_SSL": "SASL_SSL",
-		"SSL":      "SSL",
+		"SASL_SSL":  "SASL_SSL",
+		"SSL":       "SSL",
+		"PLAINTEXT": "PLAINTEXT",
 	}
 
-	expectedScheme := "https"
-	expectedHost, err := url.Parse("SSL://my-broker.host:9093")
+	expectedSchemes := []string{"https", "http"}
+	expectedHosts := []*url.URL{}
+	host, err := url.Parse("SSL://my-broker.host:9093")
+	expectedHosts = append(expectedHosts, host)
+	host, err = url.Parse("PLAINTEXT://my-broker.host:9092")
+	expectedHosts = append(expectedHosts, host)
 
-	scheme, host, err := getURLStringAndSchemeFromEndpoints(endpoints, protocolMap)
+	schemes, hosts, err := getURLStringAndSchemeFromEndpoints(endpoints, protocolMap)
 
 	if err != nil {
 		t.Fatalf("Unexpected error %s", err.Error())
 	}
-	if scheme != expectedScheme {
-		t.Errorf("Expected '%s' got '%s'", expectedScheme, scheme)
+	for i, scheme := range schemes {
+		if scheme != expectedSchemes[i] {
+			t.Errorf("Expected '%s' got '%s'", expectedSchemes[i], scheme)
+		}
 	}
-	if *host != *expectedHost {
-		t.Errorf("Expected %s got %s", expectedHost, host)
+	for i, host := range hosts {
+		if *host != *expectedHosts[i] {
+			t.Errorf("Expected %s got %s", expectedHosts[i], host)
+		}
 	}
 
 }
@@ -102,16 +129,21 @@ func Test_getUrlStringAndSchemeFromEndpoints_WithProtocolMap(t *testing.T) {
 	expectedScheme := "http"
 	expectedHost, err := url.Parse("INTERNAL://my-broker.host:9093")
 
-	scheme, host, err := getURLStringAndSchemeFromEndpoints(endpoints, protocolMap)
+	schemes, hosts, err := getURLStringAndSchemeFromEndpoints(endpoints, protocolMap)
 
 	if err != nil {
 		t.Fatalf("Unexpected error %s", err.Error())
 	}
-	if scheme != expectedScheme {
-		t.Errorf("Expected %s got %s", expectedScheme, scheme)
+
+	for _, scheme := range schemes {
+		if scheme != expectedScheme {
+			t.Errorf("Expected '%s' got '%s'", expectedScheme, scheme)
+		}
 	}
-	if *host != *expectedHost {
-		t.Errorf("Expected %q got %q", expectedHost, host)
+	for _, host := range hosts {
+		if *host != *expectedHost {
+			t.Errorf("Expected %s got %s", expectedHost, host)
+		}
 	}
 
 }


### PR DESCRIPTION
#### Description of the changes
Our setup is using multiple listeners defined in the server.properties file on a kafka cluster.
`advertised.listeners=SSL://HOSTNAME:PORT,SASL_SSL://HOSTNAME:PORT,PLAINTEXT://HOSTNAME:PORT`

The current implementation will only create a connection string to the first occurring listener in the `advertised.listeners` property. With this implementation, it will grab all the possible listeners and use the first one that has a successful connection to the kafka cluster. 

#### PR Review Checklist
### Author

- [x] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
Clean and format the code
- [x] add unit tests for your changes and make sure all unit tests are passing
- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [x] address the feedback 

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
