### PR TITLE
Added tracking on topics offsets

### DIFF
--- a/src/args/args.go
+++ b/src/args/args.go
@@ -55,6 +55,7 @@ type ArgumentList struct {
 	TopicRegex             string `default:"" help:"A regex pattern that matches the list of topics to collect. Only used if collect_topics is set to 'Regex'"`
 	TopicBucket            string `default:"1/1" help:"Allows the partitioning of topic collection across multiple instances. The second number is the number of instances topics are partitioned across. The first number is the bucket number of the current instance, which should be between 1 and the second number."`
 	CollectTopicSize       bool   `default:"false" help:"Enablement of on disk Topic size metric collection. This metric can be very resource intensive to collect especially against many topics."`
+	CollectTopicOffset     bool   `default:"false" help:"Enablement of Topic offsets collection. This metric can be very resource intensive to collect especially against many topics."`
 
 	// Consumer offset arguments
 	ConsumerOffset     bool   `default:"false" help:"Populate consumer offset data"`

--- a/src/args/args_test.go
+++ b/src/args/args_test.go
@@ -152,6 +152,7 @@ func TestDefaultArgs(t *testing.T) {
 		TopicBucket:        TopicBucket{1, 1},
 		Timeout:            10000,
 		CollectTopicSize:   false,
+		CollectTopicOffset: false,
 		ConsumerOffset:     false,
 		ConsumerGroups:     nil,
 		ConsumerGroupRegex: nil,

--- a/src/args/parsed_args.go
+++ b/src/args/parsed_args.go
@@ -68,6 +68,7 @@ type ParsedArguments struct {
 	TopicRegex            string
 	TopicBucket           TopicBucket
 	CollectTopicSize      bool
+	CollectTopicOffset    bool
 
 	// Consumer offset arguments
 	ConsumerOffset     bool
@@ -258,6 +259,7 @@ func ParseArgs(a ArgumentList) (*ParsedArguments, error) {
 		TrustStorePassword:   a.TrustStorePassword,
 		LocalOnlyCollection:  a.LocalOnlyCollection,
 		CollectTopicSize:     a.CollectTopicSize,
+		CollectTopicOffset:   a.CollectTopicOffset,
 		ConsumerOffset:       a.ConsumerOffset,
 		ConsumerGroups:       consumerGroups,
 		ConsumerGroupRegex:   consumerGroupRegex,

--- a/src/broker/broker_collection.go
+++ b/src/broker/broker_collection.go
@@ -138,6 +138,11 @@ func collectBrokerMetrics(b *connection.Broker, collectedTopics []string, i *int
 		gatherTopicSizes(b, topicSampleLookup, i)
 	}
 
+	// If enabled collect topic offset
+	if args.GlobalArgs.CollectTopicOffset {
+		gatherTopicOffset(b, topicSampleLookup, i)
+	}
+
 	// Close connection and release lock so another process can make JMX Connections
 	jmxwrapper.JMXClose()
 	jmxwrapper.JMXLock.Unlock()

--- a/src/broker/topic_offset_collection.go
+++ b/src/broker/topic_offset_collection.go
@@ -1,0 +1,59 @@
+package broker
+
+import (
+	"fmt"
+
+	"github.com/newrelic/infra-integrations-sdk/data/metric"
+	"github.com/newrelic/infra-integrations-sdk/integration"
+	"github.com/newrelic/infra-integrations-sdk/log"
+	"github.com/newrelic/nri-kafka/src/args"
+	"github.com/newrelic/nri-kafka/src/connection"
+	"github.com/newrelic/nri-kafka/src/jmxwrapper"
+	"github.com/newrelic/nri-kafka/src/metrics"
+)
+
+func gatherTopicOffset(b *connection.Broker, topicSampleLookup map[string]*metric.Set, i *integration.Integration) {
+	entity, err := b.Entity(i)
+	if err != nil {
+		log.Error("Failed to get broker entity: %s", err)
+		return
+	}
+
+	for topicName, sample := range topicSampleLookup {
+		beanModifier := metrics.ApplyTopicName(topicName)
+
+		beanName := beanModifier(metrics.TopicOffsetMetricDef.MBean)
+		results, err := jmxwrapper.JMXQuery(beanName, args.GlobalArgs.Timeout)
+		if err != nil {
+			log.Error("Broker '%s' failed to make JMX Query: %s", b.Host, err.Error())
+			continue
+		} else if len(results) == 0 {
+			continue
+		}
+
+		topicOffset, err := aggregateTopicOffset(results)
+		if err != nil {
+			log.Error("Unable to calculate offset for Topic %s: %s", topicName, err.Error())
+			continue
+		}
+
+		if err := sample.SetMetric("topic.offset", topicOffset, metric.GAUGE); err != nil {
+			log.Error("Unable to collect topic offset for Topic %s on Broker %s: %s", topicName, entity.Metadata.Name, err.Error())
+		}
+	}
+}
+
+func aggregateTopicOffset(jmxResult map[string]interface{}) (offset float64, err error) {
+	for key, value := range jmxResult {
+		partitionOffset, ok := value.(float64)
+		if !ok {
+			offset = float64(-1)
+			err = fmt.Errorf("unable to cast bean '%s' value '%v' as float64", key, value)
+			return
+		}
+
+		offset += partitionOffset
+	}
+
+	return
+}

--- a/src/broker/topic_offset_collection_test.go
+++ b/src/broker/topic_offset_collection_test.go
@@ -1,0 +1,169 @@
+package broker
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/newrelic/infra-integrations-sdk/data/metric"
+	"github.com/newrelic/infra-integrations-sdk/integration"
+	"github.com/newrelic/nri-kafka/src/connection"
+	"github.com/newrelic/nri-kafka/src/connection/mocks"
+	"github.com/newrelic/nri-kafka/src/jmxwrapper"
+	"github.com/newrelic/nri-kafka/src/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGatherTopicOffset_Single(t *testing.T) {
+	testutils.SetupJmxTesting()
+	testutils.SetupTestArgs()
+
+	i, _ := integration.New("test", "1.0.0")
+
+	jmxwrapper.JMXQuery = func(query string, timeout int) (map[string]interface{}, error) {
+		return map[string]interface{}{
+			"one":   float64(1),
+			"two":   float64(2),
+			"three": float64(3),
+			"four":  float64(4),
+		}, nil
+	}
+
+	mockBroker := &mocks.SaramaBroker{}
+	mockBroker.On("Addr").Return("kafkabroker:9090")
+
+	broker := &connection.Broker{
+		Host:         "localhost",
+		JMXPort:      9999,
+		SaramaBroker: mockBroker,
+	}
+
+	e, _ := broker.Entity(i)
+	collectedTopics := map[string]*metric.Set{
+		"topic": e.NewMetricSet("KafkaBrokerSample",
+			metric.Attribute{Key: "displayName", Value: "testEntity"},
+			metric.Attribute{Key: "entityName", Value: "broker:testEntity"},
+			metric.Attribute{Key: "topic", Value: "topic"},
+		),
+	}
+
+	gatherTopicOffset(broker, collectedTopics, i)
+
+	expected := map[string]interface{}{
+		"topic.offset": float64(10),
+		"event_type":   "KafkaBrokerSample",
+		"entityName":   "broker:testEntity",
+		"displayName":  "testEntity",
+		"topic":        "topic",
+	}
+
+	entity, err := broker.Entity(i)
+	assert.NoError(t, err)
+	assert.Len(t, entity.Metrics, 1)
+	assert.Equal(t, expected, entity.Metrics[0].Metrics)
+}
+
+func TestGatherTopicOffset_QueryError(t *testing.T) {
+	testutils.SetupJmxTesting()
+	testutils.SetupTestArgs()
+
+	i, _ := integration.New("test", "1.0.0")
+
+	jmxwrapper.JMXQuery = func(query string, timeout int) (map[string]interface{}, error) { return nil, errors.New("error") }
+
+	mockBroker := &mocks.SaramaBroker{}
+	mockBroker.On("Addr").Return("kafkabroker:9090")
+
+	broker := &connection.Broker{
+		Host:         "localhost",
+		JMXPort:      9999,
+		SaramaBroker: mockBroker,
+	}
+
+	e, _ := broker.Entity(i)
+
+	collectedTopics := map[string]*metric.Set{
+		"topic": e.NewMetricSet("KafkaBrokerSample",
+			metric.Attribute{Key: "displayName", Value: "testEntity"},
+			metric.Attribute{Key: "entityName", Value: "broker:testEntity"},
+			metric.Attribute{Key: "topic", Value: "topic"},
+		),
+	}
+
+	gatherTopicOffset(broker, collectedTopics, i)
+
+	assert.Len(t, e.Metrics, 1)
+	assert.NotContains(t, e.Metrics[0].Metrics, "topic.offset", "Metric was unexpectedly set after query error")
+}
+
+func TestGatherTopicOffset_QueryBlank(t *testing.T) {
+	testutils.SetupJmxTesting()
+	testutils.SetupTestArgs()
+
+	i, _ := integration.New("test", "1.0.0")
+
+	jmxwrapper.JMXQuery = func(query string, timeout int) (map[string]interface{}, error) {
+		return make(map[string]interface{}), nil
+	}
+
+	mockBroker := &mocks.SaramaBroker{}
+	mockBroker.On("Addr").Return("kafkabroker:9090")
+
+	broker := &connection.Broker{
+		Host:         "localhost",
+		JMXPort:      9999,
+		SaramaBroker: mockBroker,
+	}
+
+	e, _ := broker.Entity(i)
+
+	collectedTopics := map[string]*metric.Set{
+		"topic": e.NewMetricSet("KafkaBrokerSample",
+			metric.Attribute{Key: "displayName", Value: "testEntity"},
+			metric.Attribute{Key: "entityName", Value: "broker:testEntity"},
+			metric.Attribute{Key: "topic", Value: "topic"},
+		),
+	}
+
+	gatherTopicOffset(broker, collectedTopics, i)
+
+	assert.Len(t, e.Metrics, 1)
+	assert.NotContains(t, e.Metrics[0].Metrics, "topic.offset", "Metric was unexpectedly set after empty query result")
+}
+
+func TestGatherTopicOffset_AggregateError(t *testing.T) {
+	testutils.SetupJmxTesting()
+	testutils.SetupTestArgs()
+
+	i, _ := integration.New("test", "1.0.0")
+
+	jmxwrapper.JMXQuery = func(query string, timeout int) (map[string]interface{}, error) {
+		return map[string]interface{}{
+			"one":  "nope",
+			"four": float64(4),
+		}, nil
+	}
+
+	mockBroker := &mocks.SaramaBroker{}
+	mockBroker.On("Addr").Return("kafkabroker:9090")
+
+	broker := &connection.Broker{
+		Host:         "localhost",
+		JMXPort:      9999,
+		SaramaBroker: mockBroker,
+	}
+
+	e, _ := broker.Entity(i)
+
+	collectedTopics := map[string]*metric.Set{
+		"topic": e.NewMetricSet("KafkaBrokerSample",
+			metric.Attribute{Key: "displayName", Value: "testEntity"},
+			metric.Attribute{Key: "entityName", Value: "broker:testEntity"},
+			metric.Attribute{Key: "topic", Value: "topic"},
+		),
+	}
+
+	gatherTopicOffset(broker, collectedTopics, i)
+
+	assert.Len(t, e.Metrics, 1)
+	assert.NotContains(t, e.Metrics[0].Metrics, "topic.offset", "Metric was unexpectedly set after aggregate error")
+}

--- a/src/metrics/broker_definitions.go
+++ b/src/metrics/broker_definitions.go
@@ -273,6 +273,12 @@ var TopicSizeMetricDef = &JMXMetricSet{
 	MBean: "kafka.log:type=Log,name=Size,topic=" + topicHolder + ",partition=*",
 }
 
+// TopicOffsetMetricDef metric definition for calculating the roll up for a Topic's
+// offset for a given Broker
+var TopicOffsetMetricDef = &JMXMetricSet{
+	MBean: "kafka.log:type=Log,name=LogEndOffset,topic=" + topicHolder + ",partition=*",
+}
+
 // ApplyTopicName to modified bean name for Topic
 func ApplyTopicName(topicName string) BeanModifier {
 	return func(beanName string) string {


### PR DESCRIPTION
#### Description of the changes

This PR adds support for tracking Topic Offsets. The solution is very similar to collecting topic disk size which is already implemented in this project. In some cases it is useful to know how many messages were in the topics. Currently there have to be a consumer groups created to get the offset information for a topic. But in case where there is no consumer group created yet, for example when a failed messages are saved to a Dead Letter Topic (dlt), we want to create alerts or at leas be able to monitor those messages.

In our case, we have decided to create , but since we don't have yet any consumer group which can consume those messages we 

#### PR Review Checklist
### Author

- [X] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
Clean and format the code
- [X] add unit tests for your changes and make sure all unit tests are passing
- [X] add a risk label after carefully considering the "blast radius" of your changes
- [X] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [X] address the feedback 

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
