### PR TITLE
Root cert

### DIFF
--- a/kafka-config.yml.sample
+++ b/kafka-config.yml.sample
@@ -73,6 +73,17 @@ instances:
       # instance will be configured with `topic_bucket: 1/3`, one with `2/3`, and one with `3/3`
       topic_bucket: '1/3'
 
+      # block below needed if you have kafka ssl connections enforced.
+      # example on how to generate the cert and key pem files needed to work
+      # https://mapr.com/support/s/article/Convert-and-export-key-certificate-pair-from-jks-to-pkcs12-format?language=en_US
+      # key_store: /path/to/keystore.jks
+      # key_store_password: keystorepassword
+      # trust_store: /path/to/truststore.jks
+      # trust_store_password: truststorepassword
+      # client_cert: /path/to/cert.pem
+      # client_key: /path/to/key.pem
+      # root_ca: /path/to/CA.crt
+
     # Additionally, custom labels can be added to further identify your data
     labels:
       env: production

--- a/src/args/args.go
+++ b/src/args/args.go
@@ -44,6 +44,9 @@ type ArgumentList struct {
 	KeyStorePassword   string `default:"" help:"Password for the SSL Key Store"`
 	TrustStore         string `default:"" help:"The location for the keystore containing JMX Server's SSL certificate"`
 	TrustStorePassword string `default:"" help:"Password for the SSL Trust Store"`
+	ClientCert         string `default:"" help:"Full path to client certificate"`
+	ClientKey          string `default:"" help:"full path to client private key"`
+	RootCa             string `default:"" help:"full path to root ca"`
 
 	NrJmx string `default:"/usr/bin/nrjmx" help:"Path to the nrjmx executable"`
 

--- a/src/args/parsed_args.go
+++ b/src/args/parsed_args.go
@@ -97,6 +97,9 @@ type BrokerHost struct {
 	JMXPort       int    `json:"jmx_port"`
 	JMXUser       string `json:"jmx_user"`
 	JMXPassword   string `json:"jmx_password"`
+	ClientKey     string `json:"client_key"`
+	ClientCert    string `json:"client_cert"`
+	RootCa        string `json:"root_ca"`
 }
 
 // JMXHost is a storage struct for producer and consumer connection information
@@ -140,6 +143,9 @@ func ParseArgs(a ArgumentList) (*ParsedArguments, error) {
 		JMXPort:       a.BootstrapBrokerJMXPort,
 		JMXUser:       a.BootstrapBrokerJMXUser,
 		JMXPassword:   a.BootstrapBrokerJMXPassword,
+		ClientKey:     a.ClientKey,
+		ClientCert:    a.ClientCert,
+		RootCa:        a.RootCa,
 	}
 
 	if brokerHost.JMXPort == 0 {


### PR DESCRIPTION
#### Description of the changes

fixing issue describe in this ticket
https://discuss.newrelic.com/t/using-ssl-authentication-with-nri-kafka-plugin-for-newrelic-infra-agent/96964/8

If the kafka cluster has SSL enforced it does not work properly. First issue is tls needs negotiation turned on when enforce, which I set in line 161 of connections.go

Even with this turned on, there is still an issue with expectations on how the server responds when ssl enforcement is turned on. The server exepects you to also verify. This is done by adding a client key and cert, and also having the public cert of the server so it can decrypt.

this can probably be done more efficiently; (IE we could probably grab the client cert and key from the keystore), but this is all new to me so not sure the best approach to make it better. 
