### PR TITLE
Fixes #83 - add the broker id when creating the Broker client via Zookeeper

### DIFF
--- a/src/connection/connection.go
+++ b/src/connection/connection.go
@@ -372,6 +372,7 @@ func GetBrokerFromZookeeper(zkConn zookeeper.Connection, id, preferredListener s
 			log.Warn("Failed creating client: %s", err)
 			continue
 		}
+		newBroker.ID = id
 
 		return newBroker, nil
 	}


### PR DESCRIPTION

#### Description of the changes
Fixes #83 - This adds the broker id to the broker configuration when brokers are discovered via Zookeeper.

Note: I attempted to add a unit test, but the code is structured in a way that calls samara.NewClient when constructing the broker, and it would have been a larger refactor to add the test.

#### PR Review Checklist
### Author

- [X] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
Clean and format the code
- [ ] add unit tests for your changes and make sure all unit tests are passing
- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [X] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer
- [ ] address the feedback 

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
