### PR TITLE
args: make nrjmx binary name relative to PATH

### DIFF
--- a/src/args/args.go
+++ b/src/args/args.go
@@ -51,7 +51,7 @@ type ArgumentList struct {
 	TrustStore         string `default:"" help:"The location for the keystore containing JMX Server's SSL certificate"`
 	TrustStorePassword string `default:"" help:"Password for the SSL Trust Store"`
 
-	NrJmx string `default:"/usr/bin/nrjmx" help:"Path to the nrjmx executable"`
+	NrJmx string `default:"nrjmx" help:"Path to the nrjmx executable"`
 
 	SaslMechanism string `default:"GSSAPI" help:"SASL mechanism to use for authentication. One of 'PLAIN', 'SCRAM-SHA-256', 'SCRAM-SHA-512', or 'GSSAPI'"`
 	SaslUsername  string `default:"" help:"SASL username for use with the PLAIN and SCRAM mechanisms"`

--- a/src/args/args_test.go
+++ b/src/args/args_test.go
@@ -138,7 +138,7 @@ func TestDefaultArgs(t *testing.T) {
 		BootstrapBroker:              nil,
 		DefaultJMXUser:               "admin",
 		DefaultJMXPassword:           "admin",
-		NrJmx:                        "/usr/bin/nrjmx",
+		NrJmx:                        "nrjmx",
 		Producers:                    []*JMXHost{},
 		Consumers:                    []*JMXHost{},
 		TopicMode:                    "None",


### PR DESCRIPTION
While this is a simple change and should work according to [the docs](https://golang.org/pkg/os/exec/#Command), it has **not** been tested yet.

>  If name contains no path separators, Command uses LookPath to resolve name to a complete path if possible. Otherwise it uses name directly as Path. 

---
Fixes #102 