### PR TITLE
jmx: test TCP connection to all brokers on startup

### DIFF
--- a/build/ci.mk
+++ b/build/ci.mk
@@ -42,6 +42,7 @@ ci/snyk-test:
 			-v $(CURDIR):/go/src/github.com/newrelic/nri-$(INTEGRATION) \
 			-w /go/src/github.com/newrelic/nri-$(INTEGRATION) \
 			-e SNYK_TOKEN \
+			-e GO111MODULE=auto \
 			snyk/snyk:golang snyk test --severity-threshold=high
 
 .PHONY : ci/build

--- a/src/kafka.go
+++ b/src/kafka.go
@@ -70,6 +70,11 @@ func main() {
 			for _, e := range errs {
 				log.Error("%v", e)
 			}
+			log.Error(
+				"Errors were detected while probing JMX port of one or more kafka brokers. " +
+					"Please ensure that JMX is enabled in all of them, and that the port is open. " +
+					"https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration",
+			)
 			os.Exit(2)
 		}
 

--- a/src/kafka.go
+++ b/src/kafka.go
@@ -172,7 +172,7 @@ func coreCollection(kafkaIntegration *integration.Integration) {
 			return
 		}
 
-		errs := checkJMXConnection(brokers, time.Duration(args.GlobalArgs.Timeout)*time.Second)
+		errs := checkJMXConnection(brokers, time.Duration(args.GlobalArgs.Timeout)*time.Millisecond)
 		if len(errs) > 0 {
 			for _, e := range errs {
 				log.Error("%v", e)


### PR DESCRIPTION
## Motivation

Kafka integration is complex to configure, and therefore it is very easy to miss simple configuration mistakes that will prevent the integration from working.

One of the most recurring errors is not being able to connect to brokers via JMX. This PR adds a check that will attempt to open a TCP connection to the configured JMX port of all discovered brokers, and log any error encountered in the process.

Please note that this will not attempt to exercise any JMX commands, just open the connection. While this will not catch any authentication mistakes against JMX, it should be able to detect the following common mistakes when configuring kafka:

- JMX not enabled in the brokers
- JMX configured to listen on a different address as the one being used to connect to the broker
- JMX port being firewalled between the host running the integration and the brokers

### How does it look like

If JMX is disabled, the output would be something like the following (notice that verbose mode is **not** enabled):

```
/ # AUTODISCOVER_STRATEGY=bootstrap BOOTSTRAP_BROKER_HOST=broker BOOTSTRAP_BROKER_KAFKA_PORT=9092 CLUSTER_NAME=kafka_rs_test COLLECT_BROKER_TOPIC_DATA=true COLLECT_TOPIC_SIZE=false /var/db/newrelic-infra/newrelic-integrations/bin/nri-kafka
[INFO] Running core collection
[ERR] error connecting to JMX port on broker:9999: dial tcp 172.21.0.2:9999: connect: connection refused
[ERR] Errors were detected while probing JMX port of one or more kafka brokers. Please ensure that JMX is enabled in all of them, and that the port is open. https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration
```

In the agent logs, this is still readable (again, verbose logs are turned off):

```
time="2021-03-05T14:06:44Z" level=error msg="Integration command failed" error="exit status 2" instance=kafka-metrics-bootstrap-discovery integration=com.newrelic.kafka prefix=integration/com.newrelic.kafka stderr="[INFO] Running core collection\n[ERR] error connecting to JMX port on broker:9999: dial tcp 172.21.0.2:9999: connect: connection refused\n[ERR] Errors were detected while probing JMX port of one or more kafka brokers. Please ensure that JMX is enabled in all of them, and that the port is open. https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration\n" working-dir=/var/db/newrelic-infra/newrelic-integrations
```