### PR TITLE
fix(ci): prevent go get modify go.mod

### DIFF
--- a/build/release.mk
+++ b/build/release.mk
@@ -21,7 +21,7 @@ release/clean:
 .PHONY : release/deps
 release/deps: $(GORELEASER_BIN)
 	@echo "===> $(INTEGRATION) === [release/deps] install goversioninfo"
-	@go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo
+	@GO111MODULE=off go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo
 
 .PHONY : release/build
 release/build: release/deps release/clean


### PR DESCRIPTION
the project moved to go mod and the go get changes go.mod and caused the prerelease fail