### PR TITLE
NR-83900: Add Makefile target to run the rt script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ src/resource.syso
 
 # kafka encoded password
 tests/integration/jmxremote/jmxremote.password
+
+# Release toolkit
+CHANGELOG.partial.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-# Change Log
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## Unreleased
 
 ## 3.2.3 (2022-12-1)
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,15 @@ integration-test:
 	@docker-compose -f tests/integration/docker-compose.yml up -d --build
 	@go test -v -tags=integration ./tests/integration/. -count=1 ; (ret=$$?; docker-compose -f tests/integration/docker-compose.yml down && exit $$ret)
 
+# rt-update-changelog runs the release-toolkit run.sh script by piping it into bash to update the CHANGELOG.md.
+# It also passes down to the script all the flags added to the make target. To check all the accepted flags,
+# see: https://github.com/newrelic/release-toolkit/blob/main/contrib/ohi-release-notes/run.sh
+#  e.g. `make rt-update-changelog -- -v`
+rt-update-changelog:
+	curl "https://raw.githubusercontent.com/newrelic/release-toolkit/v1/contrib/ohi-release-notes/run.sh" | bash -s -- $(filter-out $@,$(MAKECMDGOALS))
+
 # Include thematic Makefiles
 include $(CURDIR)/build/ci.mk
 include $(CURDIR)/build/release.mk
 
-.PHONY: all build clean compile test
+.PHONY: all build clean compile test rt-update-changelog


### PR DESCRIPTION
Add a Makefile target to leverage running the `release-toolkit` shell [script](https://github.com/newrelic/release-toolkit/blob/main/contrib/ohi-release-notes/run.sh) to create the release-notes locally.