### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## v3.3.0 - 2023-02-20
+
+### 🛡️ Security notices
+- Bump dependencies: `github.com/Shopify/sarama` v1.37.2 --> v1.38.1
+
+### Dependencies
+- Bump to golang 1.19
+- `golang.org/x/sync` v0.0.0-20220923202941-7f9b1623fab7 --> v0.1.0
+
 ## 3.2.3 (2022-12-1)
 ### Changed
 - Bump dependencies:


### PR DESCRIPTION
I manually added the `Dependencies` section as apparently the `rt` only adds dependencies from `Renovate` or `Dependabot` commits (it doesn't detect ones like 28c2070147d223434facf84321c34b5e793d580c).

**Note**: I am using the `rt` to generate the `CHANGELOG.md`, so the format will differ from the past. For instance, we are bumping the minor instead of patching for security fixes.