### PR TITLE
NR-94443: update prerelease action

### DIFF
--- a/.github/workflows/trigger_prerelease.yml
+++ b/.github/workflows/trigger_prerelease.yml
@@ -27,18 +27,18 @@ jobs:
       - uses: newrelic/release-toolkit/contrib/ohi-release-notes@v1
         id: release-data
       - name: Configure Git
-        if: ${{ steps.release-data.outputs.is-empty == 'false' && steps.release-data.outputs.is-held == 'false' }}
+        if: ${{ steps.release-data.outputs.skip-release != 'true' }}
         run: |
           git config user.name newrelic-coreint-team
           git config user.email coreint-dev@newrelic.com
       - name: Commit updated changelog
-        if: ${{ steps.release-data.outputs.is-empty == 'false' && steps.release-data.outputs.is-held == 'false' }}
+        if: ${{ steps.release-data.outputs.skip-release != 'true' }}
         run: |
           git add CHANGELOG.md
           git commit -m "Update changelog with changes from ${{ steps.release-data.outputs.next-version }}"
           git push -u origin ${{ github.event.repository.default_branch }}
       - name: Create prerelease
-        if: ${{ steps.release-data.outputs.is-empty == 'false' && steps.release-data.outputs.is-held == 'false' }}
+        if: ${{ steps.release-data.outputs.skip-release != 'true' }}
         env:
           GH_TOKEN: "${{ secrets.COREINT_BOT_TOKEN }}"
         run: |

--- a/.github/workflows/trigger_prerelease.yml
+++ b/.github/workflows/trigger_prerelease.yml
@@ -26,17 +26,19 @@ jobs:
           token: "${{ secrets.COREINT_BOT_TOKEN }}"
       - uses: newrelic/release-toolkit/contrib/ohi-release-notes@v1
         id: release-data
-      ## TODO here in case the release is empty or on hold we should stop gracefully.
       - name: Configure Git
+        if: ${{ steps.release-data.outputs.is-empty == 'false' && steps.release-data.outputs.is-held == 'false' }}
         run: |
           git config user.name newrelic-coreint-team
           git config user.email coreint-dev@newrelic.com
       - name: Commit updated changelog
+        if: ${{ steps.release-data.outputs.is-empty == 'false' && steps.release-data.outputs.is-held == 'false' }}
         run: |
           git add CHANGELOG.md
           git commit -m "Update changelog with changes from ${{ steps.release-data.outputs.next-version }}"
           git push -u origin ${{ github.event.repository.default_branch }}
-      - name: Create preelease
+      - name: Create prerelease
+        if: ${{ steps.release-data.outputs.is-empty == 'false' && steps.release-data.outputs.is-held == 'false' }}
         env:
           GH_TOKEN: "${{ secrets.COREINT_BOT_TOKEN }}"
         run: |


### PR DESCRIPTION
**Note:** To be merged after https://github.com/newrelic/release-toolkit/pull/147.

This PR updates the prerelease actions to support the new functionality added to the `ohi-release-notes` actions of failing gracefully.

We can address the vuln in a follow-up PR. 