### PR TITLE
fix(flakyTest): adding retry mechanism to avoid failure

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -91,8 +91,10 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: 'src/github.com/${{env.ORIGINAL_REPO_NAME}}/go.mod'
+      # One of the integration consumer tests is not working as expected to the environment bootstrap, to keep it
+      # we have a simple retry mechanism spawning again the system.
       - name: Integration test
-        run: make integration-test
+        run:  for i in 1 2 3; do make integration-test && break; done
 
   test-build:
     name: Test binary compilation for all platforms:arch


### PR DESCRIPTION
There is no standard way in github actions to re-run failed steps without using a third-party action.

I manually tested run it 15 times to check a failure case and to introduce an error to see it still return errors if persistent

Notice that the test with the retry is way less flacky, but still flaky ~1/1000