### PR TITLE
chore(golang): pin golang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as builder-kafka
+FROM golang:1.20.6 as builder-kafka
 COPY . /go/src/github.com/newrelic/nri-kafka/
 RUN cd /go/src/github.com/newrelic/nri-kafka && \
     make && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-buster
+FROM golang:1.20.6-bookworm
 
 ARG GH_VERSION='1.6.0'
 

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as builder
+FROM golang:1.20.6 as builder
 ARG CGO_ENABLED=0
 ARG NRJMX_VERSION
 WORKDIR /go/src/github.com/newrelic/nri-kafka


### PR DESCRIPTION
We decided to pin golang version and [automerge them](https://github.com/newrelic/coreint-automation/commit/398ade41391d36da64320e123d832566d201601b)