### PR TITLE
feat(kafka): enforce topic collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### enhancement
 - Moved all references of sarama library from shopify to IBM
+- A new config option `ForceTopicSampleCollection` was added to collect `TopicSampleCollection` even if `LocalOnlyCollection` is enabled
 
 ## v3.4.9 - 2023-10-25
 

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,17 @@ integration-test:
 	@docker-compose -f tests/integration/docker-compose.yml up -d --build
 	@go test -v -tags=integration ./tests/integration/. -count=1 ; (ret=$$?; docker-compose -f tests/integration/docker-compose.yml down && exit $$ret)
 
+POD_NAME  := agent
+NAMESPACE := test-kafka
+ARGS := ""
+# run an agent pod with "kubectl run   agent --image newrelic/infrastructure-bundle --env="LICENSE_KEY=...."
+run-on-pod:
+	GOOS=linux GOARCH=amd64 make compile
+	kubectl cp ./bin/nri-kafka $(POD_NAME):/nri-kafka -n $(NAMESPACE)
+	@echo "=== $(INTEGRATION) === [ test ]: running kafka on pod..."
+	@echo "set ARGS to be passed to kafka binary"
+	kubectl exec -n $(NAMESPACE) $(POD_NAME) -- /nri-kafka  $(ARGS)
+
 # rt-update-changelog runs the release-toolkit run.sh script by piping it into bash to update the CHANGELOG.md.
 # It also passes down to the script all the flags added to the make target. To check all the accepted flags,
 # see: https://github.com/newrelic/release-toolkit/blob/main/contrib/ohi-release-notes/run.sh

--- a/src/args/args.go
+++ b/src/args/args.go
@@ -68,13 +68,14 @@ type ArgumentList struct {
 	SaslGssapiDisableFASTNegotiation bool   `default:"false" help:"Disable FAST negotiation."`
 
 	// Collection configuration
-	LocalOnlyCollection bool   `default:"false" help:"Collect only the metrics related to the configured bootstrap broker. Useful for distributed metric collection"`
-	TopicMode           string `default:"None" help:"Possible options are All, None, or List. If List, must also specify the list of topics to collect with the topic_list option."`
-	TopicList           string `default:"[]" help:"JSON array of strings with the names of topics to monitor. Only used if collect_topics is set to 'List'"`
-	TopicRegex          string `default:"" help:"A regex pattern that matches the list of topics to collect. Only used if collect_topics is set to 'Regex'"`
-	TopicBucket         string `default:"1/1" help:"Allows the partitioning of topic collection across multiple instances. The second number is the number of instances topics are partitioned across. The first number is the bucket number of the current instance, which should be between 1 and the second number."`
-	CollectTopicSize    bool   `default:"false" help:"Enablement of on disk Topic size metric collection. This metric can be very resource intensive to collect especially against many topics."`
-	CollectTopicOffset  bool   `default:"false" help:"Enablement of Topic offsets collection. This metric can be very resource intensive to collect especially against many topics."`
+	LocalOnlyCollection        bool   `default:"false" help:"Collect only the metrics related to the configured bootstrap broker. Useful for distributed metric collection"`
+	ForceTopicSampleCollection bool   `default:"false" help:"If LocalOnlyCollection=true it enforces the collection of the topicSample for every instance, possibly causing duplication. If LocalOnlyCollection=false it has no effects"`
+	TopicMode                  string `default:"None" help:"Possible options are All, None, or List. If List, must also specify the list of topics to collect with the topic_list option."`
+	TopicList                  string `default:"[]" help:"JSON array of strings with the names of topics to monitor. Only used if collect_topics is set to 'List'"`
+	TopicRegex                 string `default:"" help:"A regex pattern that matches the list of topics to collect. Only used if collect_topics is set to 'Regex'"`
+	TopicBucket                string `default:"1/1" help:"Allows the partitioning of topic collection across multiple instances. The second number is the number of instances topics are partitioned across. The first number is the bucket number of the current instance, which should be between 1 and the second number."`
+	CollectTopicSize           bool   `default:"false" help:"Enablement of on disk Topic size metric collection. This metric can be very resource intensive to collect especially against many topics."`
+	CollectTopicOffset         bool   `default:"false" help:"Enablement of Topic offsets collection. This metric can be very resource intensive to collect especially against many topics."`
 
 	// Consumer offset arguments
 	ConsumerOffset              bool   `default:"false" help:"Populate consumer offset data"`

--- a/src/args/parsed_args.go
+++ b/src/args/parsed_args.go
@@ -81,14 +81,15 @@ type ParsedArguments struct {
 	SaslGssapiDisableFASTNegotiation bool
 
 	// Collection configuration
-	LocalOnlyCollection   bool
-	CollectClusterMetrics bool
-	TopicMode             string
-	TopicList             []string
-	TopicRegex            string
-	TopicBucket           TopicBucket
-	CollectTopicSize      bool
-	CollectTopicOffset    bool
+	LocalOnlyCollection        bool
+	ForceTopicSampleCollection bool
+	CollectClusterMetrics      bool
+	TopicMode                  string
+	TopicList                  []string
+	TopicRegex                 string
+	TopicBucket                TopicBucket
+	CollectTopicSize           bool
+	CollectTopicOffset         bool
 
 	// Consumer offset arguments
 	ConsumerOffset              bool
@@ -246,6 +247,11 @@ func ParseArgs(a ArgumentList) (*ParsedArguments, error) {
 		}
 	}
 
+	if !a.LocalOnlyCollection && a.ForceTopicSampleCollection {
+		log.Error("ForceTopicSampleCollection has no effect if LocalOnlyCollection==false")
+		return nil, errors.New("ForceTopicSampleCollection has no effect if LocalOnlyCollection==false")
+	}
+
 	version, err := sarama.ParseKafkaVersion(a.KafkaVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse kafka version: %s", err)
@@ -282,6 +288,7 @@ func ParseArgs(a ArgumentList) (*ParsedArguments, error) {
 		TrustStore:                       a.TrustStore,
 		TrustStorePassword:               a.TrustStorePassword,
 		LocalOnlyCollection:              a.LocalOnlyCollection,
+		ForceTopicSampleCollection:       a.ForceTopicSampleCollection,
 		CollectTopicSize:                 a.CollectTopicSize,
 		CollectTopicOffset:               a.CollectTopicOffset,
 		ConsumerOffset:                   a.ConsumerOffset,

--- a/src/args/parsed_args.go
+++ b/src/args/parsed_args.go
@@ -247,11 +247,6 @@ func ParseArgs(a ArgumentList) (*ParsedArguments, error) {
 		}
 	}
 
-	if !a.LocalOnlyCollection && a.ForceTopicSampleCollection {
-		log.Error("ForceTopicSampleCollection has no effect if LocalOnlyCollection==false")
-		return nil, errors.New("ForceTopicSampleCollection has no effect if LocalOnlyCollection==false")
-	}
-
 	version, err := sarama.ParseKafkaVersion(a.KafkaVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse kafka version: %s", err)

--- a/src/kafka.go
+++ b/src/kafka.go
@@ -228,7 +228,7 @@ func coreCollection(kafkaIntegration *integration.Integration, jmxConnProvider c
 		// Start and feed all worker pools
 		brokerChan := broker.StartBrokerPool(3, &wg, kafkaIntegration, collectedTopics, jmxConnProvider)
 
-		if !args.GlobalArgs.LocalOnlyCollection {
+		if !args.GlobalArgs.LocalOnlyCollection || args.GlobalArgs.ForceTopicSampleCollection {
 			topicChan := topic.StartTopicPool(5, &wg, clusterClient)
 			go topic.FeedTopicPool(topicChan, kafkaIntegration, collectedTopics)
 		}

--- a/tests/integration/json-schema-files/kafka-schema-only-local-force-topic-collection.json
+++ b/tests/integration/json-schema-files/kafka-schema-only-local-force-topic-collection.json
@@ -1,0 +1,4306 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "required": [
+    "name",
+    "protocol_version",
+    "integration_version",
+    "data"
+  ],
+  "properties": {
+    "name": {
+      "minLength": 1,
+      "pattern": "^com.newrelic.kafka$",
+      "type": "string"
+    },
+    "protocol_version": {
+      "minLength": 1,
+      "pattern": "^3$",
+      "type": "string"
+    },
+    "integration_version": {
+      "minLength": 1,
+      "pattern": "^[0-9]+.[0-9]+.[0-9]+$",
+      "type": "string"
+    },
+    "data": {
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 2,
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "required": [
+              "entity",
+              "metrics",
+              "inventory",
+              "events"
+            ],
+            "properties": {
+              "entity": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "type",
+                  "id_attributes"
+                ],
+                "properties": {
+                  "name": {
+                    "minLength": 1,
+                    "pattern": "^kafka1*",
+                    "type": "string"
+                  },
+                  "type": {
+                    "minLength": 1,
+                    "pattern": "^ka-broker$",
+                    "type": "string"
+                  },
+                  "id_attributes": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": [
+                      {
+                        "type": "object",
+                        "required": [
+                          "Key",
+                          "Value"
+                        ],
+                        "properties": {
+                          "Key": {
+                            "type": "string"
+                          },
+                          "Value": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "Key",
+                          "Value"
+                        ],
+                        "properties": {
+                          "Key": {
+                            "type": "string"
+                          },
+                          "Value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              "metrics": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "broker.IOInPerSecond",
+                        "broker.IOOutPerSecond",
+                        "broker.messagesInPerSecond",
+                        "clusterName",
+                        "displayName",
+                        "entityName",
+                        "event_type",
+                        "net.bytesRejectedPerSecond",
+                        "replication.isrExpandsPerSecond",
+                        "replication.isrShrinksPerSecond",
+                        "replication.unreplicatedPartitions"
+                      ],
+                      "properties": {
+                        "broker.IOInPerSecond": {
+                          "type": "integer"
+                        },
+                        "broker.IOOutPerSecond": {
+                          "type": "integer"
+                        },
+                        "broker.messagesInPerSecond": {
+                          "type": "integer"
+                        },
+                        "clusterName": {
+                          "type": "string"
+                        },
+                        "displayName": {
+                          "type": "string"
+                        },
+                        "entityName": {
+                          "type": "string"
+                        },
+                        "event_type": {
+                          "type": "string"
+                        },
+                        "net.bytesRejectedPerSecond": {
+                          "type": "integer"
+                        },
+                        "replication.isrExpandsPerSecond": {
+                          "type": "integer"
+                        },
+                        "replication.isrShrinksPerSecond": {
+                          "type": "integer"
+                        },
+                        "replication.leaderElectionPerSecond": {
+                          "type": "integer"
+                        },
+                        "replication.uncleanLeaderElectionPerSecond": {
+                          "type": "integer"
+                        },
+                        "replication.unreplicatedPartitions": {
+                          "type": "integer"
+                        },
+                        "request.avgTimeFetch": {
+                          "type": "number"
+                        },
+                        "request.avgTimeMetadata": {
+                          "type": "number"
+                        },
+                        "request.avgTimeMetadata99Percentile": {
+                          "type": "number"
+                        },
+                        "request.avgTimeProduceRequest": {
+                          "type": "number"
+                        },
+                        "request.avgTimeUpdateMetadata": {
+                          "type": "number"
+                        },
+                        "request.avgTimeUpdateMetadata99Percentile": {
+                          "type": "number"
+                        },
+                        "request.clientFetchesFailedPerSecond": {
+                          "type": "number"
+                        },
+                        "request.fetchTime99Percentile": {
+                          "type": "number"
+                        },
+                        "request.handlerIdle": {
+                          "type": "number"
+                        },
+                        "request.metadataRequestsPerSecond": {
+                          "type": "number"
+                        },
+                        "request.produceRequestsFailedPerSecond": {
+                          "type": "number"
+                        },
+                        "request.produceTime99Percentile": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "clusterName",
+                        "displayName",
+                        "entityName",
+                        "event_type",
+                        "topic"
+                      ],
+                      "properties": {
+                        "clusterName": {
+                          "type": "string"
+                        },
+                        "displayName": {
+                          "type": "string"
+                        },
+                        "entityName": {
+                          "type": "string"
+                        },
+                        "event_type": {
+                          "type": "string"
+                        },
+                        "topic": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "clusterName",
+                        "displayName",
+                        "entityName",
+                        "event_type",
+                        "topic"
+                      ],
+                      "properties": {
+                        "clusterName": {
+                          "type": "string"
+                        },
+                        "displayName": {
+                          "type": "string"
+                        },
+                        "entityName": {
+                          "type": "string"
+                        },
+                        "event_type": {
+                          "type": "string"
+                        },
+                        "topic": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "clusterName",
+                        "displayName",
+                        "entityName",
+                        "event_type",
+                        "topic"
+                      ],
+                      "properties": {
+                        "clusterName": {
+                          "type": "string"
+                        },
+                        "displayName": {
+                          "type": "string"
+                        },
+                        "entityName": {
+                          "type": "string"
+                        },
+                        "event_type": {
+                          "type": "string"
+                        },
+                        "topic": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "inventory": {
+                "type": "object",
+                "required": [
+                  "broker.advertised.host.name",
+                  "broker.advertised.listeners",
+                  "broker.advertised.port",
+                  "broker.alter.config.policy.class.name",
+                  "broker.alter.log.dirs.replication.quota.window.num",
+                  "broker.alter.log.dirs.replication.quota.window.size.seconds",
+                  "broker.authorizer.class.name",
+                  "broker.auto.create.topics.enable",
+                  "broker.auto.leader.rebalance.enable",
+                  "broker.background.threads",
+                  "broker.broker.id",
+                  "broker.broker.id.generation.enable",
+                  "broker.broker.rack",
+                  "broker.client.quota.callback.class",
+                  "broker.compression.type",
+                  "broker.connection.failed.authentication.delay.ms",
+                  "broker.connections.max.idle.ms",
+                  "broker.connections.max.reauth.ms",
+                  "broker.control.plane.listener.name",
+                  "broker.controlled.shutdown.enable",
+                  "broker.controlled.shutdown.max.retries",
+                  "broker.controlled.shutdown.retry.backoff.ms",
+                  "broker.controller.quota.window.num",
+                  "broker.controller.quota.window.size.seconds",
+                  "broker.controller.socket.timeout.ms",
+                  "broker.create.topic.policy.class.name",
+                  "broker.default.replication.factor",
+                  "broker.delegation.token.expiry.check.interval.ms",
+                  "broker.delegation.token.expiry.time.ms",
+                  "broker.delegation.token.master.key",
+                  "broker.delegation.token.max.lifetime.ms",
+                  "broker.delete.records.purgatory.purge.interval.requests",
+                  "broker.delete.topic.enable",
+                  "broker.fetch.max.bytes",
+                  "broker.fetch.purgatory.purge.interval.requests",
+                  "broker.group.initial.rebalance.delay.ms",
+                  "broker.group.max.session.timeout.ms",
+                  "broker.group.max.size",
+                  "broker.group.min.session.timeout.ms",
+                  "broker.host.name",
+                  "broker.hostname",
+                  "broker.inter.broker.listener.name",
+                  "broker.inter.broker.protocol.version",
+                  "broker.jmxPort",
+                  "broker.kafka.metrics.polling.interval.secs",
+                  "broker.kafka.metrics.reporters",
+                  "broker.kafkaPort",
+                  "broker.leader.imbalance.check.interval.seconds",
+                  "broker.leader.imbalance.per.broker.percentage",
+                  "broker.listener.security.protocol.map",
+                  "broker.listeners",
+                  "broker.log.cleaner.backoff.ms",
+                  "broker.log.cleaner.dedupe.buffer.size",
+                  "broker.log.cleaner.delete.retention.ms",
+                  "broker.log.cleaner.enable",
+                  "broker.log.cleaner.io.buffer.load.factor",
+                  "broker.log.cleaner.io.buffer.size",
+                  "broker.log.cleaner.io.max.bytes.per.second",
+                  "broker.log.cleaner.max.compaction.lag.ms",
+                  "broker.log.cleaner.min.cleanable.ratio",
+                  "broker.log.cleaner.min.compaction.lag.ms",
+                  "broker.log.cleaner.threads",
+                  "broker.log.cleanup.policy",
+                  "broker.log.dir",
+                  "broker.log.dirs",
+                  "broker.log.flush.interval.messages",
+                  "broker.log.flush.interval.ms",
+                  "broker.log.flush.offset.checkpoint.interval.ms",
+                  "broker.log.flush.scheduler.interval.ms",
+                  "broker.log.flush.start.offset.checkpoint.interval.ms",
+                  "broker.log.index.interval.bytes",
+                  "broker.log.index.size.max.bytes",
+                  "broker.log.message.downconversion.enable",
+                  "broker.log.message.format.version",
+                  "broker.log.message.timestamp.difference.max.ms",
+                  "broker.log.message.timestamp.type",
+                  "broker.log.preallocate",
+                  "broker.log.retention.bytes",
+                  "broker.log.retention.check.interval.ms",
+                  "broker.log.retention.hours",
+                  "broker.log.retention.minutes",
+                  "broker.log.retention.ms",
+                  "broker.log.roll.hours",
+                  "broker.log.roll.jitter.hours",
+                  "broker.log.roll.jitter.ms",
+                  "broker.log.roll.ms",
+                  "broker.log.segment.bytes",
+                  "broker.log.segment.delete.delay.ms",
+                  "broker.max.connection.creation.rate",
+                  "broker.max.connections",
+                  "broker.max.connections.per.ip",
+                  "broker.max.connections.per.ip.overrides",
+                  "broker.max.incremental.fetch.session.cache.slots",
+                  "broker.message.max.bytes",
+                  "broker.metric.reporters",
+                  "broker.metrics.num.samples",
+                  "broker.metrics.recording.level",
+                  "broker.metrics.sample.window.ms",
+                  "broker.min.insync.replicas",
+                  "broker.num.io.threads",
+                  "broker.num.network.threads",
+                  "broker.num.partitions",
+                  "broker.num.recovery.threads.per.data.dir",
+                  "broker.num.replica.alter.log.dirs.threads",
+                  "broker.num.replica.fetchers",
+                  "broker.offset.metadata.max.bytes",
+                  "broker.offsets.commit.required.acks",
+                  "broker.offsets.commit.timeout.ms",
+                  "broker.offsets.load.buffer.size",
+                  "broker.offsets.retention.check.interval.ms",
+                  "broker.offsets.retention.minutes",
+                  "broker.offsets.topic.compression.codec",
+                  "broker.offsets.topic.num.partitions",
+                  "broker.offsets.topic.replication.factor",
+                  "broker.offsets.topic.segment.bytes",
+                  "broker.password.encoder.cipher.algorithm",
+                  "broker.password.encoder.iterations",
+                  "broker.password.encoder.key.length",
+                  "broker.password.encoder.keyfactory.algorithm",
+                  "broker.password.encoder.old.secret",
+                  "broker.password.encoder.secret",
+                  "broker.port",
+                  "broker.principal.builder.class",
+                  "broker.producer.purgatory.purge.interval.requests",
+                  "broker.queued.max.request.bytes",
+                  "broker.queued.max.requests",
+                  "broker.quota.consumer.default",
+                  "broker.quota.producer.default",
+                  "broker.quota.window.num",
+                  "broker.quota.window.size.seconds",
+                  "broker.replica.fetch.backoff.ms",
+                  "broker.replica.fetch.max.bytes",
+                  "broker.replica.fetch.min.bytes",
+                  "broker.replica.fetch.response.max.bytes",
+                  "broker.replica.fetch.wait.max.ms",
+                  "broker.replica.high.watermark.checkpoint.interval.ms",
+                  "broker.replica.lag.time.max.ms",
+                  "broker.replica.selector.class",
+                  "broker.replica.socket.receive.buffer.bytes",
+                  "broker.replica.socket.timeout.ms",
+                  "broker.replication.quota.window.num",
+                  "broker.replication.quota.window.size.seconds",
+                  "broker.request.timeout.ms",
+                  "broker.reserved.broker.max.id",
+                  "broker.sasl.client.callback.handler.class",
+                  "broker.sasl.enabled.mechanisms",
+                  "broker.sasl.jaas.config",
+                  "broker.sasl.kerberos.kinit.cmd",
+                  "broker.sasl.kerberos.min.time.before.relogin",
+                  "broker.sasl.kerberos.principal.to.local.rules",
+                  "broker.sasl.kerberos.service.name",
+                  "broker.sasl.kerberos.ticket.renew.jitter",
+                  "broker.sasl.kerberos.ticket.renew.window.factor",
+                  "broker.sasl.login.callback.handler.class",
+                  "broker.sasl.login.class",
+                  "broker.sasl.login.refresh.buffer.seconds",
+                  "broker.sasl.login.refresh.min.period.seconds",
+                  "broker.sasl.login.refresh.window.factor",
+                  "broker.sasl.login.refresh.window.jitter",
+                  "broker.sasl.mechanism.inter.broker.protocol",
+                  "broker.sasl.server.callback.handler.class",
+                  "broker.security.inter.broker.protocol",
+                  "broker.security.providers",
+                  "broker.socket.connection.setup.timeout.max.ms",
+                  "broker.socket.connection.setup.timeout.ms",
+                  "broker.socket.receive.buffer.bytes",
+                  "broker.socket.request.max.bytes",
+                  "broker.socket.send.buffer.bytes",
+                  "broker.ssl.cipher.suites",
+                  "broker.ssl.client.auth",
+                  "broker.ssl.enabled.protocols",
+                  "broker.ssl.endpoint.identification.algorithm",
+                  "broker.ssl.engine.factory.class",
+                  "broker.ssl.key.password",
+                  "broker.ssl.keymanager.algorithm",
+                  "broker.ssl.keystore.certificate.chain",
+                  "broker.ssl.keystore.key",
+                  "broker.ssl.keystore.location",
+                  "broker.ssl.keystore.password",
+                  "broker.ssl.keystore.type",
+                  "broker.ssl.principal.mapping.rules",
+                  "broker.ssl.protocol",
+                  "broker.ssl.provider",
+                  "broker.ssl.secure.random.implementation",
+                  "broker.ssl.trustmanager.algorithm",
+                  "broker.ssl.truststore.certificates",
+                  "broker.ssl.truststore.location",
+                  "broker.ssl.truststore.password",
+                  "broker.ssl.truststore.type",
+                  "broker.transaction.abort.timed.out.transaction.cleanup.interval.ms",
+                  "broker.transaction.max.timeout.ms",
+                  "broker.transaction.remove.expired.transaction.cleanup.interval.ms",
+                  "broker.transaction.state.log.load.buffer.size",
+                  "broker.transaction.state.log.min.isr",
+                  "broker.transaction.state.log.num.partitions",
+                  "broker.transaction.state.log.replication.factor",
+                  "broker.transaction.state.log.segment.bytes",
+                  "broker.transactional.id.expiration.ms",
+                  "broker.unclean.leader.election.enable",
+                  "broker.zookeeper.clientCnxnSocket",
+                  "broker.zookeeper.connect",
+                  "broker.zookeeper.connection.timeout.ms",
+                  "broker.zookeeper.max.in.flight.requests",
+                  "broker.zookeeper.session.timeout.ms",
+                  "broker.zookeeper.set.acl",
+                  "broker.zookeeper.ssl.cipher.suites",
+                  "broker.zookeeper.ssl.client.enable",
+                  "broker.zookeeper.ssl.crl.enable",
+                  "broker.zookeeper.ssl.enabled.protocols",
+                  "broker.zookeeper.ssl.endpoint.identification.algorithm",
+                  "broker.zookeeper.ssl.keystore.location",
+                  "broker.zookeeper.ssl.keystore.password",
+                  "broker.zookeeper.ssl.keystore.type",
+                  "broker.zookeeper.ssl.ocsp.enable",
+                  "broker.zookeeper.ssl.protocol",
+                  "broker.zookeeper.ssl.truststore.location",
+                  "broker.zookeeper.ssl.truststore.password",
+                  "broker.zookeeper.ssl.truststore.type",
+                  "broker.zookeeper.sync.time.ms"
+                ],
+                "properties": {
+                  "broker.advertised.host.name": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.advertised.listeners": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.advertised.port": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.alter.config.policy.class.name": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.alter.log.dirs.replication.quota.window.num": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.alter.log.dirs.replication.quota.window.size.seconds": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.authorizer.class.name": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.auto.create.topics.enable": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.auto.leader.rebalance.enable": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.background.threads": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.broker.id": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.broker.id.generation.enable": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.broker.rack": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.client.quota.callback.class": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.compression.type": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.connection.failed.authentication.delay.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.connections.max.idle.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.connections.max.reauth.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.control.plane.listener.name": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.controlled.shutdown.enable": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.controlled.shutdown.max.retries": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.controlled.shutdown.retry.backoff.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.controller.quota.window.num": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.controller.quota.window.size.seconds": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.controller.socket.timeout.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.create.topic.policy.class.name": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.default.replication.factor": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.delegation.token.expiry.check.interval.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.delegation.token.expiry.time.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.delegation.token.master.key": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.delegation.token.max.lifetime.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.delete.records.purgatory.purge.interval.requests": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.delete.topic.enable": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.fetch.max.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.fetch.purgatory.purge.interval.requests": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.group.initial.rebalance.delay.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.group.max.session.timeout.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.group.max.size": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.group.min.session.timeout.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.host.name": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.hostname": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.inter.broker.listener.name": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.inter.broker.protocol.version": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.jmxPort": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "integer"
+                      }
+                    }
+                  },
+                  "broker.kafka.metrics.polling.interval.secs": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.kafka.metrics.reporters": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.kafkaPort": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.leader.imbalance.check.interval.seconds": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.leader.imbalance.per.broker.percentage": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.listener.security.protocol.map": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.listeners": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.cleaner.backoff.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.cleaner.dedupe.buffer.size": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.cleaner.delete.retention.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.cleaner.enable": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.cleaner.io.buffer.load.factor": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.cleaner.io.buffer.size": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.cleaner.io.max.bytes.per.second": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.cleaner.max.compaction.lag.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.cleaner.min.cleanable.ratio": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.cleaner.min.compaction.lag.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.cleaner.threads": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.cleanup.policy": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.dir": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.dirs": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.flush.interval.messages": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.flush.interval.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.flush.offset.checkpoint.interval.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.flush.scheduler.interval.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.flush.start.offset.checkpoint.interval.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.index.interval.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.index.size.max.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.message.downconversion.enable": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.message.format.version": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.message.timestamp.difference.max.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.message.timestamp.type": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.preallocate": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.retention.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.retention.check.interval.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.retention.hours": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.retention.minutes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.retention.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.roll.hours": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.roll.jitter.hours": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.roll.jitter.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.roll.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.segment.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.log.segment.delete.delay.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.max.connection.creation.rate": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.max.connections": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.max.connections.per.ip": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.max.connections.per.ip.overrides": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.max.incremental.fetch.session.cache.slots": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.message.max.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.metric.reporters": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.metrics.num.samples": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.metrics.recording.level": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.metrics.sample.window.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.min.insync.replicas": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.num.io.threads": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.num.network.threads": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.num.partitions": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.num.recovery.threads.per.data.dir": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.num.replica.alter.log.dirs.threads": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.num.replica.fetchers": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.offset.metadata.max.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.offsets.commit.required.acks": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.offsets.commit.timeout.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.offsets.load.buffer.size": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.offsets.retention.check.interval.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.offsets.retention.minutes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.offsets.topic.compression.codec": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.offsets.topic.num.partitions": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.offsets.topic.replication.factor": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.offsets.topic.segment.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.password.encoder.cipher.algorithm": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.password.encoder.iterations": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.password.encoder.key.length": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.password.encoder.keyfactory.algorithm": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.password.encoder.old.secret": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.password.encoder.secret": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.port": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.principal.builder.class": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.producer.purgatory.purge.interval.requests": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.queued.max.request.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.queued.max.requests": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.quota.consumer.default": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.quota.producer.default": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.quota.window.num": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.quota.window.size.seconds": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.replica.fetch.backoff.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.replica.fetch.max.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.replica.fetch.min.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.replica.fetch.response.max.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.replica.fetch.wait.max.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.replica.high.watermark.checkpoint.interval.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.replica.lag.time.max.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.replica.selector.class": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.replica.socket.receive.buffer.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.replica.socket.timeout.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.replication.quota.window.num": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.replication.quota.window.size.seconds": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.request.timeout.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.reserved.broker.max.id": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.sasl.client.callback.handler.class": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.sasl.enabled.mechanisms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.sasl.jaas.config": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.sasl.kerberos.kinit.cmd": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.sasl.kerberos.min.time.before.relogin": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.sasl.kerberos.principal.to.local.rules": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.sasl.kerberos.service.name": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.sasl.kerberos.ticket.renew.jitter": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.sasl.kerberos.ticket.renew.window.factor": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.sasl.login.callback.handler.class": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.sasl.login.class": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.sasl.login.refresh.buffer.seconds": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.sasl.login.refresh.min.period.seconds": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.sasl.login.refresh.window.factor": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.sasl.login.refresh.window.jitter": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.sasl.mechanism.inter.broker.protocol": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.sasl.server.callback.handler.class": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.security.inter.broker.protocol": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.security.providers": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.socket.connection.setup.timeout.max.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.socket.connection.setup.timeout.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.socket.receive.buffer.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.socket.request.max.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.socket.send.buffer.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.cipher.suites": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.client.auth": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.enabled.protocols": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.endpoint.identification.algorithm": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.engine.factory.class": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.key.password": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.keymanager.algorithm": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.keystore.certificate.chain": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.keystore.key": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.keystore.location": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.keystore.password": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.keystore.type": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.principal.mapping.rules": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.protocol": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.provider": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.secure.random.implementation": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.trustmanager.algorithm": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.truststore.certificates": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.truststore.location": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.truststore.password": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.ssl.truststore.type": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.transaction.abort.timed.out.transaction.cleanup.interval.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.transaction.max.timeout.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.transaction.remove.expired.transaction.cleanup.interval.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.transaction.state.log.load.buffer.size": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.transaction.state.log.min.isr": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.transaction.state.log.num.partitions": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.transaction.state.log.replication.factor": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.transaction.state.log.segment.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.transactional.id.expiration.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.unclean.leader.election.enable": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.clientCnxnSocket": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.connect": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.connection.timeout.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.max.in.flight.requests": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.session.timeout.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.set.acl": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.ssl.cipher.suites": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.ssl.client.enable": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.ssl.crl.enable": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.ssl.enabled.protocols": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.ssl.endpoint.identification.algorithm": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.ssl.keystore.location": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.ssl.keystore.password": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.ssl.keystore.type": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.ssl.ocsp.enable": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.ssl.protocol": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.ssl.truststore.location": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.ssl.truststore.password": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.ssl.truststore.type": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "broker.zookeeper.sync.time.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "events": {
+                "type": "array",
+                "uniqueItems": true
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "entity",
+              "metrics",
+              "inventory",
+              "events"
+            ],
+            "properties": {
+              "entity": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "type",
+                  "id_attributes"
+                ],
+                "properties": {
+                  "name": {
+                    "minLength": 1,
+                    "pattern": "^__consumer_offsets*",
+                    "type": "string"
+                  },
+                  "type": {
+                    "minLength": 1,
+                    "pattern": "^ka-topic$",
+                    "type": "string"
+                  },
+                  "id_attributes": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "Key",
+                        "Value"
+                      ],
+                      "properties": {
+                        "Key": {
+                          "type": "string"
+                        },
+                        "Value": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "metrics": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "clusterName",
+                    "displayName",
+                    "entityName",
+                    "event_type",
+                    "topic.partitionsWithNonPreferredLeader",
+                    "topic.respondsToMetadataRequests",
+                    "topic.underReplicatedPartitions"
+                  ],
+                  "properties": {
+                    "clusterName": {
+                      "type": "string"
+                    },
+                    "displayName": {
+                      "type": "string"
+                    },
+                    "entityName": {
+                      "type": "string"
+                    },
+                    "event_type": {
+                      "type": "string"
+                    },
+                    "topic.partitionsWithNonPreferredLeader": {
+                      "type": "integer"
+                    },
+                    "topic.respondsToMetadataRequests": {
+                      "type": "integer"
+                    },
+                    "topic.underReplicatedPartitions": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "inventory": {
+                "type": "object",
+                "required": [],
+                "properties": {}
+              },
+              "events": {
+                "type": "array",
+                "uniqueItems": true
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "entity",
+              "metrics",
+              "inventory",
+              "events"
+            ],
+            "properties": {
+              "entity": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "type",
+                  "id_attributes"
+                ],
+                "properties": {
+                  "name": {
+                    "minLength": 1,
+                    "pattern": "^topicA*",
+                    "type": "string"
+                  },
+                  "type": {
+                    "minLength": 1,
+                    "pattern": "^ka-topic$",
+                    "type": "string"
+                  },
+                  "id_attributes": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "Key",
+                        "Value"
+                      ],
+                      "properties": {
+                        "Key": {
+                          "type": "string"
+                        },
+                        "Value": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "metrics": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "clusterName",
+                    "displayName",
+                    "entityName",
+                    "event_type",
+                    "topic.partitionsWithNonPreferredLeader",
+                    "topic.respondsToMetadataRequests",
+                    "topic.underReplicatedPartitions"
+                  ],
+                  "properties": {
+                    "clusterName": {
+                      "type": "string"
+                    },
+                    "displayName": {
+                      "type": "string"
+                    },
+                    "entityName": {
+                      "type": "string"
+                    },
+                    "event_type": {
+                      "type": "string"
+                    },
+                    "topic.partitionsWithNonPreferredLeader": {
+                      "type": "integer"
+                    },
+                    "topic.respondsToMetadataRequests": {
+                      "type": "integer"
+                    },
+                    "topic.underReplicatedPartitions": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "inventory": {
+                "type": "object",
+                "required": [
+                  "topic.cleanup.policy",
+                  "topic.compression.type",
+                  "topic.delete.retention.ms",
+                  "topic.file.delete.delay.ms",
+                  "topic.flush.messages",
+                  "topic.flush.ms",
+                  "topic.follower.replication.throttled.replicas",
+                  "topic.index.interval.bytes",
+                  "topic.leader.replication.throttled.replicas",
+                  "topic.max.compaction.lag.ms",
+                  "topic.max.message.bytes",
+                  "topic.message.downconversion.enable",
+                  "topic.message.format.version",
+                  "topic.message.timestamp.difference.max.ms",
+                  "topic.message.timestamp.type",
+                  "topic.min.cleanable.dirty.ratio",
+                  "topic.min.compaction.lag.ms",
+                  "topic.min.insync.replicas",
+                  "topic.partitionScheme",
+                  "topic.preallocate",
+                  "topic.retention.bytes",
+                  "topic.retention.ms",
+                  "topic.segment.bytes",
+                  "topic.segment.index.bytes",
+                  "topic.segment.jitter.ms",
+                  "topic.segment.ms",
+                  "topic.unclean.leader.election.enable"
+                ],
+                "properties": {
+                  "topic.cleanup.policy": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.compression.type": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.delete.retention.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.file.delete.delay.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.flush.messages": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.flush.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.follower.replication.throttled.replicas": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.index.interval.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.leader.replication.throttled.replicas": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.max.compaction.lag.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.max.message.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.message.downconversion.enable": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.message.format.version": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.message.timestamp.difference.max.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.message.timestamp.type": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.min.cleanable.dirty.ratio": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.min.compaction.lag.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.min.insync.replicas": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.partitionScheme": {
+                    "type": "object",
+                    "required": [
+                      "Number of Partitions",
+                      "Replication Factor"
+                    ],
+                    "properties": {
+                      "Number of Partitions": {
+                        "type": "integer"
+                      },
+                      "Replication Factor": {
+                        "type": "integer"
+                      }
+                    }
+                  },
+                  "topic.preallocate": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.retention.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.retention.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.segment.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.segment.index.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.segment.jitter.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.segment.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.unclean.leader.election.enable": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "events": {
+                "type": "array",
+                "uniqueItems": true
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "entity",
+              "metrics",
+              "inventory",
+              "events"
+            ],
+            "properties": {
+              "entity": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "type",
+                  "id_attributes"
+                ],
+                "properties": {
+                  "name": {
+                    "minLength": 1,
+                    "pattern": "^topicB*",
+                    "type": "string"
+                  },
+                  "type": {
+                    "minLength": 1,
+                    "pattern": "^ka-topic$",
+                    "type": "string"
+                  },
+                  "id_attributes": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "Key",
+                        "Value"
+                      ],
+                      "properties": {
+                        "Key": {
+                          "type": "string"
+                        },
+                        "Value": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "metrics": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "clusterName",
+                    "displayName",
+                    "entityName",
+                    "event_type",
+                    "topic.partitionsWithNonPreferredLeader",
+                    "topic.respondsToMetadataRequests",
+                    "topic.underReplicatedPartitions"
+                  ],
+                  "properties": {
+                    "clusterName": {
+                      "type": "string"
+                    },
+                    "displayName": {
+                      "type": "string"
+                    },
+                    "entityName": {
+                      "type": "string"
+                    },
+                    "event_type": {
+                      "type": "string"
+                    },
+                    "topic.partitionsWithNonPreferredLeader": {
+                      "type": "integer"
+                    },
+                    "topic.respondsToMetadataRequests": {
+                      "type": "integer"
+                    },
+                    "topic.underReplicatedPartitions": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "inventory": {
+                "type": "object",
+                "required": [
+                  "topic.cleanup.policy",
+                  "topic.compression.type",
+                  "topic.delete.retention.ms",
+                  "topic.file.delete.delay.ms",
+                  "topic.flush.messages",
+                  "topic.flush.ms",
+                  "topic.follower.replication.throttled.replicas",
+                  "topic.index.interval.bytes",
+                  "topic.leader.replication.throttled.replicas",
+                  "topic.max.compaction.lag.ms",
+                  "topic.max.message.bytes",
+                  "topic.message.downconversion.enable",
+                  "topic.message.format.version",
+                  "topic.message.timestamp.difference.max.ms",
+                  "topic.message.timestamp.type",
+                  "topic.min.cleanable.dirty.ratio",
+                  "topic.min.compaction.lag.ms",
+                  "topic.min.insync.replicas",
+                  "topic.partitionScheme",
+                  "topic.preallocate",
+                  "topic.retention.bytes",
+                  "topic.retention.ms",
+                  "topic.segment.bytes",
+                  "topic.segment.index.bytes",
+                  "topic.segment.jitter.ms",
+                  "topic.segment.ms",
+                  "topic.unclean.leader.election.enable"
+                ],
+                "properties": {
+                  "topic.cleanup.policy": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.compression.type": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.delete.retention.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.file.delete.delay.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.flush.messages": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.flush.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.follower.replication.throttled.replicas": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.index.interval.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.leader.replication.throttled.replicas": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.max.compaction.lag.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.max.message.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.message.downconversion.enable": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.message.format.version": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.message.timestamp.difference.max.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.message.timestamp.type": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.min.cleanable.dirty.ratio": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.min.compaction.lag.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.min.insync.replicas": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.partitionScheme": {
+                    "type": "object",
+                    "required": [
+                      "Number of Partitions",
+                      "Replication Factor"
+                    ],
+                    "properties": {
+                      "Number of Partitions": {
+                        "type": "integer"
+                      },
+                      "Replication Factor": {
+                        "type": "integer"
+                      }
+                    }
+                  },
+                  "topic.preallocate": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.retention.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.retention.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.segment.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.segment.index.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.segment.jitter.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.segment.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.unclean.leader.election.enable": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "events": {
+                "type": "array",
+                "uniqueItems": true
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "entity",
+              "metrics",
+              "inventory",
+              "events"
+            ],
+            "properties": {
+              "entity": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "type",
+                  "id_attributes"
+                ],
+                "properties": {
+                  "name": {
+                    "minLength": 1,
+                    "pattern": "^topicC*",
+                    "type": "string"
+                  },
+                  "type": {
+                    "minLength": 1,
+                    "pattern": "^ka-topic$",
+                    "type": "string"
+                  },
+                  "id_attributes": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "Key",
+                        "Value"
+                      ],
+                      "properties": {
+                        "Key": {
+                          "type": "string"
+                        },
+                        "Value": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "metrics": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "clusterName",
+                    "displayName",
+                    "entityName",
+                    "event_type",
+                    "topic.partitionsWithNonPreferredLeader",
+                    "topic.respondsToMetadataRequests",
+                    "topic.underReplicatedPartitions"
+                  ],
+                  "properties": {
+                    "clusterName": {
+                      "type": "string"
+                    },
+                    "displayName": {
+                      "type": "string"
+                    },
+                    "entityName": {
+                      "type": "string"
+                    },
+                    "event_type": {
+                      "type": "string"
+                    },
+                    "topic.partitionsWithNonPreferredLeader": {
+                      "type": "integer"
+                    },
+                    "topic.respondsToMetadataRequests": {
+                      "type": "integer"
+                    },
+                    "topic.underReplicatedPartitions": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "inventory": {
+                "type": "object",
+                "required": [
+                  "topic.cleanup.policy",
+                  "topic.compression.type",
+                  "topic.delete.retention.ms",
+                  "topic.file.delete.delay.ms",
+                  "topic.flush.messages",
+                  "topic.flush.ms",
+                  "topic.follower.replication.throttled.replicas",
+                  "topic.index.interval.bytes",
+                  "topic.leader.replication.throttled.replicas",
+                  "topic.max.compaction.lag.ms",
+                  "topic.max.message.bytes",
+                  "topic.message.downconversion.enable",
+                  "topic.message.format.version",
+                  "topic.message.timestamp.difference.max.ms",
+                  "topic.message.timestamp.type",
+                  "topic.min.cleanable.dirty.ratio",
+                  "topic.min.compaction.lag.ms",
+                  "topic.min.insync.replicas",
+                  "topic.partitionScheme",
+                  "topic.preallocate",
+                  "topic.retention.bytes",
+                  "topic.retention.ms",
+                  "topic.segment.bytes",
+                  "topic.segment.index.bytes",
+                  "topic.segment.jitter.ms",
+                  "topic.segment.ms",
+                  "topic.unclean.leader.election.enable"
+                ],
+                "properties": {
+                  "topic.cleanup.policy": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.compression.type": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.delete.retention.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.file.delete.delay.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.flush.messages": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.flush.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.follower.replication.throttled.replicas": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.index.interval.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.leader.replication.throttled.replicas": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.max.compaction.lag.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.max.message.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.message.downconversion.enable": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.message.format.version": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.message.timestamp.difference.max.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.message.timestamp.type": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.min.cleanable.dirty.ratio": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.min.compaction.lag.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.min.insync.replicas": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.partitionScheme": {
+                    "type": "object",
+                    "required": [
+                      "Number of Partitions",
+                      "Replication Factor"
+                    ],
+                    "properties": {
+                      "Number of Partitions": {
+                        "type": "integer"
+                      },
+                      "Replication Factor": {
+                        "type": "integer"
+                      }
+                    }
+                  },
+                  "topic.preallocate": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.retention.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.retention.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.segment.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.segment.index.bytes": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.segment.jitter.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.segment.ms": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "topic.unclean.leader.election.enable": {
+                    "type": "object",
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "events": {
+                "type": "array",
+                "uniqueItems": true
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/integration/kafka_test.go
+++ b/tests/integration/kafka_test.go
@@ -297,7 +297,7 @@ func TestKafkaIntegration_bootstrap_localOnlyCollection(t *testing.T) {
 
 func TestKafkaIntegration_bootstrap_localOnlyCollectionEnforcingTopicCollection(t *testing.T) {
 	bootstrapDiscoverConfigLocalOnlyCollection := func(command []string) []string {
-		return append(bootstrapDiscoverConfig(command), "--local_only_collection -force_topic_sample_collection")
+		return append(bootstrapDiscoverConfig(command), "--local_only_collection", "--force_topic_sample_collection")
 	}
 
 	stdout, stderr, err := runIntegration(t, bootstrapDiscoverConfigLocalOnlyCollection)

--- a/tests/integration/kafka_test.go
+++ b/tests/integration/kafka_test.go
@@ -295,6 +295,24 @@ func TestKafkaIntegration_bootstrap_localOnlyCollection(t *testing.T) {
 	}
 }
 
+func TestKafkaIntegration_bootstrap_localOnlyCollectionEnforcingTopicCollection(t *testing.T) {
+	bootstrapDiscoverConfigLocalOnlyCollection := func(command []string) []string {
+		return append(bootstrapDiscoverConfig(command), "--local_only_collection -force_topic_sample_collection")
+	}
+
+	stdout, stderr, err := runIntegration(t, bootstrapDiscoverConfigLocalOnlyCollection)
+
+	assert.NotNil(t, stderr, "unexpected stderr")
+	assert.NoError(t, err, "Unexpected error")
+
+	schemaPath := filepath.Join("json-schema-files", "kafka-schema-only-local.json")
+	err = jsonschema.Validate(schemaPath, stdout)
+	assert.NoError(t, err, "The output of kafka integration doesn't have expected format.")
+	for _, topic := range topicNames {
+		assert.Contains(t, stdout, topic, fmt.Sprintf("The output doesn't have the topic %s", topic))
+	}
+}
+
 func TestKafkaIntegration_bootstrap_metrics(t *testing.T) {
 	bootstrapDiscoverConfigMetrics := func(command []string) []string {
 		return append(bootstrapDiscoverConfig(command), "--metrics")

--- a/tests/integration/kafka_test.go
+++ b/tests/integration/kafka_test.go
@@ -305,7 +305,7 @@ func TestKafkaIntegration_bootstrap_localOnlyCollectionEnforcingTopicCollection(
 	assert.NotNil(t, stderr, "unexpected stderr")
 	assert.NoError(t, err, "Unexpected error")
 
-	schemaPath := filepath.Join("json-schema-files", "kafka-schema-only-local.json")
+	schemaPath := filepath.Join("json-schema-files", "kafka-schema-only-local-force-topic-collection.json")
 	err = jsonschema.Validate(schemaPath, stdout)
 	assert.NoError(t, err, "The output of kafka integration doesn't have expected format.")
 	for _, topic := range topicNames {


### PR DESCRIPTION
Adding
 -  a flag to enforce topic collection even if `local-only-collection=true` with basic integration test and corresponding JSON schema
 - a make target to run the integration remotely. Running it locally even if it is possible with port forwarding it is not ideal due to the requirement of nrjmx. I did not update the integration test to an arm image since the canary could be already deployed locally