### PR TITLE
[NR-286408] chore: update docker compose command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ integration-test:
 	fi
 	@cp tests/integration/jmxremote/jmxremote.password.unencoded tests/integration/jmxremote/jmxremote.password
 	@chmod 0600 tests/integration/jmxremote/jmxremote.password
-	@docker-compose -f tests/integration/docker-compose.yml up -d --build
-	@go test -v -tags=integration ./tests/integration/. -count=1 ; (ret=$$?; docker-compose -f tests/integration/docker-compose.yml down && exit $$ret)
+	@docker compose -f tests/integration/docker-compose.yml up -d --build
+	@go test -v -tags=integration ./tests/integration/. -count=1 ; (ret=$$?; docker compose -f tests/integration/docker-compose.yml down && exit $$ret)
 
 POD_NAME  := agent
 NAMESPACE := test-kafka


### PR DESCRIPTION
`docker-compose` v1 is EOL, and we need to move to `docker compose` (wit a space).