### PR TITLE
fix: Included topic.name as it is required for creating a topic entity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### enhancements
+- Included topic.name as it is required for creating a topic entity
+
 ## v3.11.0 - 2025-04-23
 
 ### ⛓️ Dependencies

--- a/src/topic/topic_collection.go
+++ b/src/topic/topic_collection.go
@@ -261,6 +261,11 @@ func populateTopicInventory(t *Topic) []error {
 		errors = append(errors, err)
 	}
 
+	var topicKey, _ = t.Entity.Metadata.Key();
+	if err := t.Entity.SetInventoryItem("topic.name", "value", topicKey.String()); err != nil {
+		errors = append(errors, err)
+	}
+	
 	// Add topic configs to inventory
 	for _, config := range t.Configs {
 		if err := t.Entity.SetInventoryItem("topic."+config.Name, "value", config.Value); err != nil {

--- a/src/topic/topic_collection.go
+++ b/src/topic/topic_collection.go
@@ -261,11 +261,11 @@ func populateTopicInventory(t *Topic) []error {
 		errors = append(errors, err)
 	}
 
-	var topicKey, _ = t.Entity.Metadata.Key();
+	var topicKey, _ = t.Entity.Metadata.Key()
 	if err := t.Entity.SetInventoryItem("topic.name", "value", topicKey.String()); err != nil {
 		errors = append(errors, err)
 	}
-	
+
 	// Add topic configs to inventory
 	for _, config := range t.Configs {
 		if err := t.Entity.SetInventoryItem("topic."+config.Name, "value", config.Value); err != nil {

--- a/src/topic/topic_collection_test.go
+++ b/src/topic/topic_collection_test.go
@@ -115,6 +115,7 @@ func TestPopulateTopicInventory(t *testing.T) {
 
 	i, _ := integration.New("kafka", "1.0.0")
 	e, _ := i.Entity("testtopic", "topic")
+	var key, _ = e.Metadata.Key();
 
 	myTopic := &Topic{
 		Entity:            e,
@@ -136,6 +137,9 @@ func TestPopulateTopicInventory(t *testing.T) {
 		},
 		"topic.flush.messages": {
 			"value": "12345",
+		},
+		"topic.name": {
+			"value": key.String(),
 		},
 	}
 

--- a/src/topic/topic_collection_test.go
+++ b/src/topic/topic_collection_test.go
@@ -115,7 +115,7 @@ func TestPopulateTopicInventory(t *testing.T) {
 
 	i, _ := integration.New("kafka", "1.0.0")
 	e, _ := i.Entity("testtopic", "topic")
-	var key, _ = e.Metadata.Key();
+	var key, _ = e.Metadata.Key()
 
 	myTopic := &Topic{
 		Entity:            e,


### PR DESCRIPTION
https://source.datanerd.us/meatballs/backend/blob/f6fe147e6d1be5d12c71976f9b6fdaa34885838e/shared/inventory/metadata.go#L325C37-L325C47

<img width="1712" alt="Screenshot 2025-06-17 at 3 02 46 PM" src="https://github.com/user-attachments/assets/cb5f8c2d-9f66-441c-9bb0-7a45d4221241" />
<img width="1305" alt="Screenshot 2025-06-17 at 4 49 58 PM" src="https://github.com/user-attachments/assets/555c7fbf-a199-4776-bf80-5e299b18e0f2" />
