### PR TITLE
fix: collect KafkaTopicSample on Kafka 4.x (DescribeConfigs version)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Bugfixes
+- Fixed missing `KafkaTopicSample` data on Kafka 4.x. The integration sent `DescribeConfigs` requests at API version 0, which Kafka 4.0 removed (the broker minimum is now v1), causing topic configuration collection to fail and the topic samples to be dropped entirely. The request version is now derived from the configured `KAFKA_VERSION` (v2/v1/v0), and the default `KAFKA_VERSION` was raised from `1.0.0` to `2.1.0` so topic and broker configuration collection works against Kafka 4.x out of the box.
+
 ## v3.20.0 - 2026-06-17
 
 ### 🛡️ Security notices

--- a/src/args/args.go
+++ b/src/args/args.go
@@ -10,7 +10,7 @@ import (
 type ArgumentList struct {
 	sdkArgs.DefaultArgumentList
 	ClusterName  string `default:"" help:"A user-defined name to uniquely identify the cluster"`
-	KafkaVersion string `default:"1.0.0" help:"What version of the API to use for connecting to Kafka. Versions older than 1.0.0 may be missing some features."`
+	KafkaVersion string `default:"2.1.0" help:"What version of the API to use for connecting to Kafka. Defaults to 2.1.0. Set this to match your cluster's version. Kafka 4.x requires at least 2.0.0 for topic and broker configuration collection (DescribeConfigs v0 was removed). Versions older than 1.0.0 may be missing some features."`
 
 	AutodiscoverStrategy string `default:"zookeeper" help:"How to discover broker nodes to collect metrics from. One of 'zookeeper' (default) or 'bootstrap'"`
 

--- a/src/args/args_test.go
+++ b/src/args/args_test.go
@@ -126,7 +126,7 @@ func TestDefaultArgs(t *testing.T) {
 			CacheTTL:  persist.DefaultTTL,
 		},
 		AutodiscoverStrategy: "zookeeper",
-		KafkaVersion:         sarama.V1_0_0_0,
+		KafkaVersion:         sarama.V2_1_0_0,
 		ZookeeperHosts: []*ZookeeperHost{
 			{
 				Host: "localhost",

--- a/src/broker/broker_collection.go
+++ b/src/broker/broker_collection.go
@@ -191,9 +191,20 @@ func collectBrokerTopicMetrics(b *connection.Broker, collectedTopics []string, i
 // Collect broker configuration from Zookeeper
 func getBrokerConfig(broker *connection.Broker) ([]*sarama.ConfigEntry, error) {
 
+	// DescribeConfigs v0 was removed in Kafka 4.0 (the broker's minimum supported
+	// version is now v1). Derive the request version from the negotiated Kafka
+	// version so we remain compatible with both older brokers and Kafka 4.x.
+	// sarama v1.43.x supports DescribeConfigs up to v2.
+	descVer := int16(0)
+	switch {
+	case args.GlobalArgs.KafkaVersion.IsAtLeast(sarama.V2_0_0_0):
+		descVer = 2
+	case args.GlobalArgs.KafkaVersion.IsAtLeast(sarama.V1_1_0_0):
+		descVer = 1
+	}
 	configRequest := &sarama.DescribeConfigsRequest{
-		Version:         0,
-		IncludeSynonyms: true,
+		Version:         descVer,
+		IncludeSynonyms: descVer >= 1,
 		Resources: []*sarama.ConfigResource{
 			{
 				Type:        sarama.BrokerResource,

--- a/src/topic/topic_collection.go
+++ b/src/topic/topic_collection.go
@@ -206,9 +206,20 @@ func topicRespondsToMetadata(t *Topic, client connection.Client) int {
 
 // Collect and populate the remainder of the topic struct fields
 func setTopicInfo(t *Topic, client connection.Client) error {
+	// DescribeConfigs v0 was removed in Kafka 4.0 (the broker's minimum supported
+	// version is now v1). Derive the request version from the negotiated Kafka
+	// version so we remain compatible with both older brokers and Kafka 4.x.
+	// sarama v1.43.x supports DescribeConfigs up to v2.
+	descVer := int16(0)
+	switch {
+	case args.GlobalArgs.KafkaVersion.IsAtLeast(sarama.V2_0_0_0):
+		descVer = 2
+	case args.GlobalArgs.KafkaVersion.IsAtLeast(sarama.V1_1_0_0):
+		descVer = 1
+	}
 	configRequest := &sarama.DescribeConfigsRequest{
-		Version:         0,
-		IncludeSynonyms: true,
+		Version:         descVer,
+		IncludeSynonyms: descVer >= 1,
 		Resources: []*sarama.ConfigResource{
 			{
 				Type:        sarama.TopicResource,


### PR DESCRIPTION
## Summary
`KafkaTopicSample` is missing on Kafka 4.x clusters while `KafkaBrokerSample`, `KafkaProducerSample`, `KafkaConsumerSample`, and `KafkaOffsetSample` continue to report. 

**Root Cause:** The integration issues `DescribeConfigs` requests at API version 0, which Kafka 4.0 removed (the broker's minimum supported version is now v1, per KIP-896). The v0 request is rejected by the broker, `setTopicInfo()` returns an error, and `topicWorker()` continues before the topic metric set is created — so the topic sample is dropped entirely. Broker/producer/consumer/offset samples are JMX- or higher-level-API-based, so they remain unaffected.

This was reproduced and verified on a real Kafka 3.8.1 (works) vs 4.0.0 (topic samples missing) cluster, confirmed both via the integration's `-pretty` output and in NRDB.

---

## Changes

* **`src/topic/topic_collection.go`, `src/broker/broker_collection.go`**: Derive the `DescribeConfigs` request version from the negotiated `KAFKA_VERSION` instead of hardcoding 0.
    * Logic: `>= 2.0.0` → `v2`, `>= 1.1.0` → `v1`, else `v0`. (Sarama v1.43.x supports `DescribeConfigs` up to `v2`; Kafka 4.0 supports 1–4). `IncludeSynonyms` is now set only when the version supports it (>= 1).
* **`src/args/args.go`**: Raise the default `KAFKA_VERSION` from `1.0.0` to `2.1.0`. This ensures topic/broker config collection works against Kafka 4.x out of the box without requiring manual user configuration.
* **`src/args/args_test.go`**: Updated `TestDefaultArgs` expectation to match the new default.
* **`CHANGELOG.md`**: Added unreleased bug-fix entry.

---

## Why both changes are needed
Sarama refuses to send a request whose `requiredVersion()` exceeds `config.Version` (within `broker.go`). Simply fixing the hardcoded version is insufficient; with the old `1.0.0` default, a `v2` (or even `v1`) request is rejected client-side. Bumping the default ensures functionality for Kafka 4.x users without forcing manual configuration changes. Deriving the version (rather than hardcoding `v2`) ensures we do not regress support for genuinely older brokers.

---

## Testing
* **Unit Tests**: `go test ./src/...` passes.
* **Manual/Agent Testing**: Ran against a live single-node KRaft cluster:
    * **Kafka 3.8.1**: All sample types present (baseline, unchanged).
    * **Kafka 4.0.0 (Before)**: `KafkaTopicSample = 0`, `DescribeConfigs` errors.
    * **Kafka 4.0.0 (After, no `KAFKA_VERSION` set)**: `KafkaTopicSample` present for all topics, 0 `DescribeConfigs` errors; confirmed in NRDB.

---

## Compatibility / Notes
* No behavior change for Kafka < 4.0 except the higher default protocol version (`2.1.0`), which negotiates down per-API via `ApiVersions`.
* **Future Considerations**: Upgrade Sarama to a release that natively supports Kafka 4.x (DescribeConfigs v4 / flexible versions), and improve error handling to make a malformed `KAFKA_VERSION` non-fatal (falling back to default instead of aborting the whole run).