### PR TITLE
feat: add metric missing in kafka v4

### DIFF
--- a/src/metrics/producer_definitions.go
+++ b/src/metrics/producer_definitions.go
@@ -55,7 +55,7 @@ var producerMetricDefs = []*JMXMetricSet{
 				JMXAttr:    "client-id=" + producerHolder + ",attr=bufferpool-wait-time-total",
 			},
 			{
-				Name:       "producer.bufferpoolWaitTimeNs",
+				Name:       "producer.bufferpoolWaitTime",
 				SourceType: metric.GAUGE,
 				JMXAttr:    "client-id=" + producerHolder + ",attr=bufferpool-wait-time-ns-total",
 			},

--- a/src/metrics/producer_definitions.go
+++ b/src/metrics/producer_definitions.go
@@ -55,6 +55,11 @@ var producerMetricDefs = []*JMXMetricSet{
 				JMXAttr:    "client-id=" + producerHolder + ",attr=bufferpool-wait-time-total",
 			},
 			{
+				Name:       "producer.bufferpoolWaitTimeNs",
+				SourceType: metric.GAUGE,
+				JMXAttr:    "client-id=" + producerHolder + ",attr=bufferpool-wait-time-ns-total",
+			},
+			{
 				Name:       "producer.bytesOutPerSecond",
 				SourceType: metric.GAUGE,
 				JMXAttr:    "client-id=" + producerHolder + ",attr=outgoing-byte-rate",


### PR DESCRIPTION
This mbean `bufferpool-wait-time-total` was renamed in kafka v4 to `bufferpool-wait-time-ns-total`
[release notes](https://kafka.apache.org/39/operations/monitoring/) 